### PR TITLE
GAME_LOSE state

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -16,7 +16,8 @@ enum GameState
     GAME_PLAYING,
     GAME_ROUND_END,
     GAME_SHOP,
-    GAME_BLIND_SELECT
+    GAME_BLIND_SELECT,
+    GAME_LOSE,
 };
 
 enum HandState

--- a/source/game.c
+++ b/source/game.c
@@ -19,7 +19,7 @@ static int timer = 1; // This might already exist in libtonc but idk so i'm just
 static int game_speed = 1;
 static int background = 0;
 
-static enum GameState game_state = GAME_ROUND_END;
+static enum GameState game_state = GAME_PLAYING;
 static enum HandState hand_state = HAND_DRAW;
 static enum PlayState play_state = PLAY_PLAYING;
 
@@ -1233,6 +1233,10 @@ static void game_playing_ui_text_update()
 
 void game_playing()
 {
+    if (hand_state == HAND_SELECT && hands == 0) {
+        game_state = GAME_LOSE;
+    }
+
     // Background logic (thissss might be moved to the card'ssss logic later. I'm a sssssnake)
     if (hand_state == HAND_DRAW || hand_state == HAND_DISCARD || hand_state == HAND_SELECT)
     {
@@ -1345,6 +1349,9 @@ void game_update()
             break;
         case GAME_BLIND_SELECT:
             // Handle blind select logic here
+            break;
+        case GAME_LOSE:
+            // Handle lose logic here
             break;
     }
 }


### PR DESCRIPTION
When at 0 hands, the game changes into a `GAME_LOSE` state. There is no code to actually handle it, it simply exists to help with adding a lose screen in the future

This also sets the initial game state to GAME_PLAYING, instead of GAME_ROUND_END