### PR TITLE
Removed redundant copy of shadow buffer into OAM.

### DIFF
--- a/source/sprite.c
+++ b/source/sprite.c
@@ -98,7 +98,6 @@ void sprite_init()
 
 void sprite_draw()
 {
-    obj_copy(obj_mem, obj_buffer, MAX_SPRITES);
     obj_aff_copy(obj_aff_mem, obj_aff_buffer, MAX_AFFINES);
     oam_copy(oam_mem, obj_buffer, MAX_SPRITES);
 }


### PR DESCRIPTION
This may make me a shameless one-line-change-merchant, but since obj_mem and oam_mem point to the same place I figured the extra copy was redundant.