### PR TITLE
Refactor - Replaced magic number copies with main_bg_se_copy_rect()

### DIFF
--- a/include/graphic_utils.h
+++ b/include/graphic_utils.h
@@ -113,7 +113,7 @@ void main_bg_se_copy_rect_1_tile_vert(Rect se_rect, int direction);
  * se_rect dimensions are in number of tiles.
  * x and y are the coordinates in number of tiles.
  */
-void main_bg_se_copy_rect(Rect se_rect, BG_POINT pos);
+void main_bg_se_copy_rect(Rect se_rect, BG_POINT dest_pos);
 
 /* Copies a screen entry to a rect in the main background.
  * se_rect dimensions are in number of tiles.

--- a/source/game.c
+++ b/source/game.c
@@ -382,7 +382,6 @@ static const Rect POP_MENU_ANIM_RECT        = {9,       7,      24,     31 };
 // the whole rect so we don't have to track its position
 
 static const Rect SINGLE_BLIND_SELECT_RECT  = {9,       7,      13,     31 };
-static const Rect BLIND_SELECT_BTN_PREANIM_RECT = {10,  20,     12,     20 };
 static const Rect BLIND_SKIP_BTN_GRAY_RECT  = {0,       24,     4,      27 };
 static const Rect BLIND_SKIP_BTN_PREANIM_DEST_RECT = {9,29,     19,     31 };
 // preanim - pre-animation rects for before the pop-up animation
@@ -845,28 +844,29 @@ void change_background(int id)
             curr_blind_rect.left += i * rect_width(&SINGLE_BLIND_SELECT_RECT);
             curr_blind_rect.right += i * rect_width(&SINGLE_BLIND_SELECT_RECT);
 
-            if (blinds[i] != BLIND_CURRENT && (i == SMALL_BLIND || i == BIG_BLIND)) // Make the skip button gray
+            if (blinds[i] != BLIND_STATE_CURRENT && (i == BLIND_TYPE_SMALL || i == BLIND_TYPE_BIG)) // Make the skip button gray
             {
-                Rect skip_blind_btn_dest_rect = BLIND_SKIP_BTN_PREANIM_DEST_RECT;
-                skip_blind_btn_dest_rect.left = curr_blind_rect.left;
-                skip_blind_btn_dest_rect.right = curr_blind_rect.right; 
-                Rect skip_blind_btn_src_rect = BLIND_SKIP_BTN_GRAY_RECT;
-                skip_blind_btn_src_rect.top += i * rect_height(&BLIND_SKIP_BTN_GRAY_RECT);
-                skip_blind_btn_src_rect.bottom += i * rect_height(&BLIND_SKIP_BTN_GRAY_RECT);
+                BG_POINT skip_blind_btn_pos_dest = { BLIND_SKIP_BTN_PREANIM_DEST_RECT.left, BLIND_SKIP_BTN_PREANIM_DEST_RECT.top };
+                skip_blind_btn_pos_dest.x = curr_blind_rect.left;
 
-                main_bg_se_copy_rect(skip_blind_btn_dest_rect, skip_blind_btn_src_rect);
+                Rect skip_blind_btn_rect_src = BLIND_SKIP_BTN_GRAY_RECT;
+                skip_blind_btn_rect_src.top += i * rect_height(&BLIND_SKIP_BTN_GRAY_RECT);
+                skip_blind_btn_rect_src.bottom += i * rect_height(&BLIND_SKIP_BTN_GRAY_RECT);
+
+                main_bg_se_copy_rect(skip_blind_btn_rect_src, skip_blind_btn_pos_dest);
             }
 
             switch(blinds[i]) {
                 case BLIND_STATE_CURRENT: // Raise the blind panel up a bit
                 {
+                    // TODO: Replace copies with main_bg_se_copy_rect() of named rects
                     int x_from = 0;
                     int y_from = 27;
 
-                main_bg_se_copy_rect_1_tile_vert(curr_blind_rect, SE_UP);
+                    main_bg_se_copy_rect_1_tile_vert(curr_blind_rect, SE_UP);
 
-                int x_to = curr_blind_rect.left;
-                int y_to = 31;
+                    int x_to = curr_blind_rect.left;
+                    int y_to = 31;
 
                     if (i == BLIND_TYPE_BIG)
                     {
@@ -891,8 +891,8 @@ void change_background(int id)
                     int x_from = 0;
                     int y_from = 20;
 
-                int x_to = 10 + (i * rect_width(&SINGLE_BLIND_SELECT_RECT));
-                int y_to = 20;
+                    int x_to = 10 + (i * rect_width(&SINGLE_BLIND_SELECT_RECT));
+                    int y_to = 20;
 
                     memcpy16(&se_mem[MAIN_BG_SBB][x_to + 32 * y_to], &se_mem[MAIN_BG_SBB][x_from + 32 * y_from], 3);
                     break;

--- a/source/graphic_utils.c
+++ b/source/graphic_utils.c
@@ -112,7 +112,7 @@ void main_bg_se_move_rect_1_tile_vert(Rect se_rect, int direction)
     main_bg_se_copy_or_move_rect_1_tile_vert(se_rect, direction, true);
 }
 
-void main_bg_se_copy_rect(Rect se_rect, BG_POINT pos)
+void main_bg_se_copy_rect(Rect se_rect, BG_POINT dest_pos)
 {
     if (se_rect.left > se_rect.right || se_rect.top > se_rect.bottom)
         return;
@@ -136,7 +136,7 @@ void main_bg_se_copy_rect(Rect se_rect, BG_POINT pos)
     // Copy the tilemap to the new rect position
     for (int sy = 0; sy < height; sy++)
     {
-        memcpy16(&se_mat[MAIN_BG_SBB][pos.y + sy][pos.x],
+        memcpy16(&se_mat[MAIN_BG_SBB][dest_pos.y + sy][dest_pos.x],
                  &tile_map[sy][0],
                  width);
     }


### PR DESCRIPTION
Apparently I had a branch in my fork with a commit from July that partially had this old TODO done. 😅 
I guess I never pushed it because it was a work in progress but I suppose it's better to have at least some of it done than none of it at all.

I didn't give this code much thought now, just merged it from the old branch, fixed some errors, and tested to see nothing is wrong with the Blind selection graphics.