### PR TITLE
Fix permissions issue for nightly workflow

### DIFF
--- a/.github/workflows/nightly_release_ci_workflow.yml
+++ b/.github/workflows/nightly_release_ci_workflow.yml
@@ -1,5 +1,8 @@
 name: Deploy Nightly
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC


### PR DESCRIPTION
Hot fix to address failed run for nightly: https://github.com/cellos51/balatro-gba/actions/runs/18992592826

Note, I have it tricking the CI into building as part of this pull request to test it before merging to main.