### PR TITLE
Junk directories on release zip

### DIFF
--- a/.github/workflows/nightly_release_ci_workflow.yml
+++ b/.github/workflows/nightly_release_ci_workflow.yml
@@ -29,7 +29,7 @@ jobs:
           path: build
 
       - name: Package Release
-        run: mv build/balatro-gba.gba build/balatro-gba_nightly_$(date +'%+4Y%m%d')_$(cat build/githash.txt).gba && zip release.zip build/*.gba
+        run: mv build/balatro-gba.gba build/balatro-gba_nightly_$(date +'%+4Y%m%d')_$(cat build/githash.txt).gba && zip -j release build/*.gba
 
       - name: Deploy release
         uses: WebFreak001/deploy-nightly@v3.2.0


### PR DESCRIPTION
The zipfiles from the release workflow have the `build/` directory still present. 

I'm adding a `-j` (`--junk-paths`) and also removing the `.zip` from the command. 

This isn't fixing anything broken, it's just annoying me, lol.