### PR TITLE
Add gba-dev pacman installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,17 @@ Disregard Steps 3-4 and instead click the green code button on the main reposito
 > Apple Silicon: https://pkg.devkitpro.org/packages/macos-installers/devkitpro-pacman-installer.arm64.pkg
 
 > Intel: https://pkg.devkitpro.org/packages/macos-installers/devkitpro-pacman-installer.x86_64.pkg
- 
 
-2.) Verify that devkitPro is installed in '/opt/devkitpro'
+2.) Run `sudo dkp-pacman -S gba-dev`
 
-3.) Add the following to your .bashrc or .zshrc (or export the variables in your shell session): 
+3.) Verify that devkitPro is installed in '/opt/devkitpro'
+
+4.) Add the following to your .bashrc or .zshrc (or export the variables in your shell session): 
 - export DEVKITPRO=/opt/devkitpro
 - export DEVKITARM=$DEVKITPRO/devkitARM
 - export PATH=$PATH:$DEVKITPRO/tools/bin:$DEVKITPRO/pacman/bin
 
-4.) Follow instructions from Windows tutorial step 4
+5.) Follow instructions from Windows tutorial step 4
 
 ## **Common Issues:**
 


### PR DESCRIPTION
Rearranged installation steps for clarity and added a command to install gba-dev.

I ran into the following error before running the added command:

Makefile:9: /opt/devkitpro/devkitARM/gba_rules: No such file or directory
make: *** No rule to make target `/opt/devkitpro/devkitARM/gba_rules'.  Stop.