### PR TITLE
Optimized score lerping by changing the step to a power of 2

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -1600,7 +1600,10 @@ static void game_playing_process_hand_select_input()
     }
 }
 
-#define SCORE_LERP_STEP 32
+/* This needs to stay a power of 2 and small enough
+ * for the lerping to be done before the next hand is drawn.
+ */ 
+#define NUM_SCORE_LERP_STEPS 32
 
 static void game_playing_process_input_and_state()
 {
@@ -1626,9 +1629,13 @@ static void game_playing_process_input_and_state()
     }
     else if (play_state == PLAY_ENDED)
     {
-        // TODO: Why is this using fixed point?
-        lerped_temp_score -= int2fx(temp_score * get_game_speed()) / SCORE_LERP_STEP;
-        lerped_score += int2fx(temp_score * get_game_speed()) / SCORE_LERP_STEP;
+        /* Using fixed point in case the score is lower than NUM_SCORE_LERP_STEPS and then
+         * then the division rounds it down to 0 and it's never added to the total.
+         * The operation is equivalent to 
+         * fxdiv(int2fx(temp_score * get_game_speed()), int2fx(NUM_SCORE_LERP_STEPS))
+         */
+        lerped_temp_score -= int2fx(temp_score * get_game_speed()) / NUM_SCORE_LERP_STEPS;
+        lerped_score += int2fx(temp_score * get_game_speed()) / NUM_SCORE_LERP_STEPS;
 
         if (lerped_temp_score > 0)
         {


### PR DESCRIPTION
The number 40 previously chosen here seems to be quite arbitrary and has a performance impact because it would call a division subroutine. Changing it to a power of 2 would switch it to a shift operation that would be much faster. Since this is just a transfer of chunks of the hand score to the total round score the exact number of steps is not that significant as long as it's short enough to finish before the next hand is drawn. I also changed the magic number to a named define of course. Also thought it's weird it's using fixed point but haven't given it too much thought, left it as a TODO to check later.

Edit: the TODO is done and I added a comment explaining, I couldn't help but take the time to understand it.
I also checked the assembly to make sure this actually removes the call to the division subroutine.