### PR TITLE
Added credits to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Disregard Steps 3-4 and instead click the green code button on the main reposito
 This GBA implementation is based on Balatro which is designed and created by LocalThunk and published by Playstack.
 See repository contributors list for code contribution credits to this GBA implementation.
 ## **Music**
-Music arrangement made by @cellos51 is based on original Balatro soundtrack by [LouisF](https://louisfmusic.com/) and [transcription by MrCrimit](https://musescore.com/user/8237321/scores/14590660).
+Music arrangement is made by @cellos51 based on original Balatro soundtrack by [LouisF](https://louisfmusic.com/) and [transcription by MrCrimit](https://musescore.com/user/8237321/scores/14590660).
 ## **Imagery**
 Sprites and backgrounds are based on original Balatro imagery created by LocalThunk.
 See [Joker Art Discussion](https://github.com/cellos51/balatro-gba/discussions/69) for full credits for each joker sprite.


### PR DESCRIPTION
Added credits to README.md detailing credits for each part and crediting original Balatro creators. Made so sound effects added in #229 can be credited under license.
I'm still thinking about adding more credits for everything we made and changing the wording a bit so I'm making this a draft for now.
Edit: Can't think of anything more to add, so undrafting it and will merge soon.