### PR TITLE
Fixed bug where reroll button is triggered by any key

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -3911,6 +3911,11 @@ static inline void game_shop_reroll(int* reroll_cost)
 
 static void shop_reroll_row_on_key_hit(SelectionGrid* selection_grid, Selection* selection)
 {
+    if (!key_hit(SELECT_CARD))
+    {
+        return;
+    }
+
     if (money >= reroll_cost)
     {
         game_shop_reroll(&reroll_cost);


### PR DESCRIPTION
This fix needs to be merged with or before #258 because it makes this bug worse.