### PR TITLE
Added blind score requirement and reward in blind select screen

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -220,6 +220,8 @@ static void game_blind_select_start_anim_seq(void);
 static void game_blind_select_handle_input(void);
 static void game_blind_select_selected_anim_seq(void);
 static void game_blind_select_display_blind_panel(void);
+static Rect game_blind_select_get_req_score_rect(enum BlindType blind);
+static void game_blind_select_print_blinds_reqs_and_rewards(void);
 static void game_round_end_start(void);
 static void game_round_end_start_expand_popup(void);
 static void game_round_end_display_finished_blind(void);
@@ -4364,7 +4366,7 @@ static void game_blind_select_on_update()
     blind_select_state_actions[substate]();
 }
 
-static void game_blind_select_erase_blind_reqs_and_rewards()
+static inline void game_blind_select_erase_blind_reqs_and_rewards()
 {
     for (enum BlindType curr_blind = 0; curr_blind < BLIND_TYPE_MAX; curr_blind++)
     {
@@ -4450,7 +4452,7 @@ static inline void game_blind_select_print_blind_reward(enum BlindType blind)
     );
 }
 
-static void game_blind_select_print_blinds_reqs_and_rewards()
+static void game_blind_select_print_blinds_reqs_and_rewards(void)
 {
     for (enum BlindType curr_blind = 0; curr_blind < BLIND_TYPE_MAX; curr_blind++)
     {


### PR DESCRIPTION
I added score requirement and reward display in the blind select screen. I used the score truncation to squeeze them into 3 tiles there.
I also did a small refactor to rename the `blinds` array into `blind_states` to make it a little clearer.

https://github.com/user-attachments/assets/5be6c95a-c973-4cb7-be56-4fe11eea9e48

Since the truncation is so extreme and rounded down, it's sometimes a little awkward like on ante 2 where it looks like both the Big Blind and Boss Blind have the same score requirement of 1K when in fact it's 1200 and 1600.

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/aedfeee0-cf31-4dd0-84c7-7a44abbbe1ec" />

Another screenshot of the infamous ante 5
<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/ee01c765-ca16-4a70-84cd-bc393bab0d8b" />

And on ante 8 there is inevitable overflow but it's handled as well as possible.


https://github.com/user-attachments/assets/08073de4-1400-48a7-82e6-f12313e9f346

