### PR TITLE
Renamed GBLA_UNUSED -> GBAL_UNUSED and updated documentation

### DIFF
--- a/include/selection_grid.h
+++ b/include/selection_grid.h
@@ -19,9 +19,10 @@ typedef void (*RowOnSelectionChangedFunc)(
     const Selection* new_selection
 );
 typedef int (*RowGetSizeFunc)();
-// Called for any non-directional key hit
-// The key will not be passed, the function will have to check key_hit() etc. for the key it wants
-// to check
+
+// Called for any non-directional key transit (either hit down or release up)
+// The key itself and hit/release event will not be passed,
+// the function will have to check key_hit(), key_released() etc. for the key it wants to check
 typedef void (*RowOnKeyTransitFunc)(SelectionGrid* selection_grid, Selection* selection);
 
 struct SelectionGridRow

--- a/include/util.h
+++ b/include/util.h
@@ -10,10 +10,10 @@
 #include <stdint.h>
 
 /**
- * @def GBLA_UNUSED
+ * @def GBAL_UNUSED
  * @brief A friendly wrapper around the not so friendly looking __attribute__ syntax for ((unused))
  */
-#define GBLA_UNUSED __attribute__((unused))
+#define GBAL_UNUSED __attribute__((unused))
 
 #define UNDEFINED -1
 

--- a/source/blind.c
+++ b/source/blind.c
@@ -45,7 +45,7 @@ static Blind _blind_type_map[BLIND_TYPE_MAX] = {
 
 static void s_blind_gfx_init(enum BlindType type);
 
-GBLA_UNUSED
+GBAL_UNUSED
 void blind_set_boss_graphics(const unsigned int* tiles, const u16* palette)
 {
     // TODO: This function is unused and not fully fleshed out.

--- a/source/game.c
+++ b/source/game.c
@@ -551,7 +551,7 @@ static int shortcut_joker_count = 0;
 static int four_fingers_joker_count = 0;
 static int straight_and_flush_size = STRAIGHT_AND_FLUSH_SIZE_DEFAULT;
 
-GBLA_UNUSED
+GBAL_UNUSED
 static inline bool is_shop_joker_avail(int joker_id)
 {
     return bitset_get_idx(&_avail_jokers_bitset, joker_id);

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -1459,10 +1459,10 @@ static u32 bootstraps_joker_effect(
     return effect_flags_ret;
 }
 
-// Using GBLA_UNUSED, aka __attribute__((unused)), for jokers with no sprites yet to avoid warning
+// Using GBAL_UNUSED, aka __attribute__((unused)), for jokers with no sprites yet to avoid warning
 // Remove the attribute once they have sprites
 // no graphics available but ready to be used if wanted when graphics available
-GBLA_UNUSED
+GBAL_UNUSED
 static u32 shoot_the_moon_joker_effect(
     Joker* joker,
     Card* scored_card,
@@ -1485,7 +1485,7 @@ static u32 shoot_the_moon_joker_effect(
     return effect_flags_ret;
 }
 
-GBLA_UNUSED
+GBAL_UNUSED
 static u32 photograph_joker_effect(
     Joker* joker,
     Card* scored_card,


### PR DESCRIPTION
Just a few small addendums to previous PRs. I renamed GBLA to GBAL so it's short for GBALATRO and updated the documentation for RowOnKeyTransitFunc() to match the changes in PR #258.