### PR TITLE
Refactor - move `selected` field from SpriteObject to CardObject

### DIFF
--- a/include/card.h
+++ b/include/card.h
@@ -51,6 +51,7 @@ typedef struct CardObject
 {
     Card* card;
     SpriteObject* sprite_object;
+    bool selected;
 } CardObject;
 
 // Card functions

--- a/include/joker.h
+++ b/include/joker.h
@@ -176,9 +176,6 @@ bool joker_object_score(
     enum JokerEvent joker_event
 );
 
-void joker_object_set_selected(JokerObject* joker_object, bool selected);
-bool joker_object_is_selected(JokerObject* joker_object);
-
 Sprite* joker_object_get_sprite(JokerObject* joker_object);
 int joker_get_random_rarity();
 

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -16,7 +16,7 @@ typedef struct
     int idx;
 } Sprite;
 
-// A sprite object is a sprite that is selectable and movable in animation
+// A sprite object is a sprite that is focusable and movable in animation
 typedef struct
 {
     Sprite* sprite;
@@ -29,7 +29,6 @@ typedef struct
     FIXED trotation; // this never gets used so i might remove it later
     FIXED rotation;
     FIXED vrotation;
-    bool selected;
     bool focused;
 
 } SpriteObject;
@@ -53,8 +52,6 @@ void sprite_object_reset_transform(SpriteObject* sprite_object);
 void sprite_object_update(SpriteObject* sprite_object);
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id);
 
-void sprite_object_set_selected(SpriteObject* sprite_object, bool selected);
-bool sprite_object_is_selected(SpriteObject* sprite_object);
 Sprite* sprite_object_get_sprite(SpriteObject* sprite_object);
 void sprite_object_set_focus(SpriteObject* sprite_object, bool focus);
 bool sprite_object_is_focused(SpriteObject* sprite_object);

--- a/source/card.c
+++ b/source/card.c
@@ -66,6 +66,7 @@ CardObject* card_object_new(Card* card)
 
     card_object->card = card;
     card_object->sprite_object = sprite_object_new();
+    card_object->selected = false;
 
     return card_object;
 }
@@ -114,14 +115,14 @@ void card_object_set_selected(CardObject* card_object, bool selected)
 {
     if (card_object == NULL)
         return;
-    sprite_object_set_selected(card_object->sprite_object, selected);
+    card_object->selected = selected;
 }
 
 bool card_object_is_selected(CardObject* card_object)
 {
     if (card_object == NULL)
         return false;
-    return sprite_object_is_selected(card_object->sprite_object);
+    return card_object->selected;
 }
 
 Sprite* card_object_get_sprite(CardObject* card_object)

--- a/source/joker.c
+++ b/source/joker.c
@@ -320,20 +320,6 @@ bool joker_object_score(
     return true;
 }
 
-void joker_object_set_selected(JokerObject* joker_object, bool selected)
-{
-    if (joker_object == NULL)
-        return;
-    sprite_object_set_selected(joker_object->sprite_object, selected);
-}
-
-bool joker_object_is_selected(JokerObject* joker_object)
-{
-    if (joker_object == NULL)
-        return false;
-    return sprite_object_is_selected(joker_object->sprite_object);
-}
-
 Sprite* joker_object_get_sprite(JokerObject* joker_object)
 {
     if (joker_object == NULL)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -129,7 +129,6 @@ SpriteObject* sprite_object_new()
     SpriteObject* sprite_object = POOL_GET(SpriteObject);
     sprite_object->sprite = NULL;
     sprite_object_reset_transform(sprite_object);
-    sprite_object->selected = false;
     sprite_object->focused = false;
 
     return sprite_object;
@@ -243,20 +242,6 @@ void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
         return; // If no sound ID is provided, do nothing
 
     play_sfx(sound_id, MM_BASE_PITCH_RATE);
-}
-
-void sprite_object_set_selected(SpriteObject* sprite_object, bool selected)
-{
-    if (sprite_object == NULL)
-        return;
-    sprite_object->selected = selected;
-}
-
-bool sprite_object_is_selected(SpriteObject* sprite_object)
-{
-    if (sprite_object == NULL)
-        return false;
-    return sprite_object->selected;
 }
 
 Sprite* sprite_object_get_sprite(SpriteObject* sprite_object)


### PR DESCRIPTION
This field was only used by cards but not by jokers so it shouldn't be in the more generic SpriteObject struct.