### PR TITLE
Used proper text centering for price printing

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -142,26 +142,4 @@ static inline int u32_get_digits(uint32_t n)
     return 10;
 }
 
-/**
- * @brief Get the number of digits closest to it's "even" value, i.e. ceil(digits/2)
- *
- * Useful for centering text on tiles
- *
- * @param n value to find the number of even decimal digits of
- *
- * @return The value of ceil(get_digits(n)/2)
- */
-static inline int get_digits_even(int n)
-{
-    if (n < 100)
-        return 1;
-    if (n < 10000)
-        return 2;
-    if (n < 1000000)
-        return 3;
-    if (n < 100000000)
-        return 4;
-    return 5;
-}
-
 #endif // UTIL_H

--- a/source/game.c
+++ b/source/game.c
@@ -3515,26 +3515,10 @@ static void game_round_end_dismiss_round_end_panel()
     }
 }
 
-static void print_price_under_sprite_object(SpriteObject* sprite_object, int price)
+static Rect get_text_rect_under_sprite_object(SpriteObject* sprite_object)
 {
     int height = 0;
-
-    if (sprite_object_get_height(sprite_object, &height) == false)
-    {
-        // fallback
-        height = CARD_SPRITE_SIZE;
-    }
-
-    int x = fx2int(sprite_object->tx) + TILE_SIZE - (get_digits_even(price) - 1) * TILE_SIZE;
-    int y = fx2int(sprite_object->ty) + height + TILE_SIZE;
-
-    tte_printf("#{P:%d,%d; cx:0x%X000}$%d", x, y, TTE_YELLOW_PB, price);
-}
-
-static void erase_price_under_sprite_object(SpriteObject* sprite_object)
-{
     int width = 0;
-    int height = 0;
 
     if (sprite_object_get_dimensions(sprite_object, &width, &height) == false)
     {
@@ -3543,11 +3527,35 @@ static void erase_price_under_sprite_object(SpriteObject* sprite_object)
         width = CARD_SPRITE_SIZE;
     }
 
-    Rect price_rect;
-    price_rect.left = fx2int(sprite_object->tx);
-    price_rect.top = fx2int(sprite_object->ty) + height + TILE_SIZE;
-    price_rect.right = price_rect.left + width;
-    price_rect.bottom = price_rect.top + TILE_SIZE + SPRITE_FOCUS_RAISE_PX;
+    Rect ret_rect = {0};
+
+    ret_rect.left = fx2int(sprite_object->tx);
+    ret_rect.top = fx2int(sprite_object->ty) + height + TILE_SIZE;
+    ret_rect.right = ret_rect.left + width;
+    ret_rect.bottom = ret_rect.top + TTE_CHAR_SIZE;
+
+    return ret_rect;
+}
+
+static void print_price_under_sprite_object(SpriteObject* sprite_object, int price)
+{
+    Rect price_rect = get_text_rect_under_sprite_object(sprite_object);
+
+    char price_str_buff[INT_MAX_DIGITS + 2]; // + 2 for null-terminator and "$"
+
+    snprintf(price_str_buff, sizeof(price_str_buff), "$%d", price);
+
+    update_text_rect_to_center_str(&price_rect, price_str_buff, SCREEN_LEFT);
+
+    tte_printf("#{P:%d,%d; cx:0x%X000}$%d", price_rect.left, price_rect.top, TTE_YELLOW_PB, price);
+}
+
+static void erase_price_under_sprite_object(SpriteObject* sprite_object)
+{
+    Rect price_rect = get_text_rect_under_sprite_object(sprite_object);
+
+    // Add SPRITE_FOCUS_RAISE_PX to cover the focused case
+    price_rect.bottom = price_rect.bottom + SPRITE_FOCUS_RAISE_PX;
 
     tte_erase_rect_wrapper(price_rect);
 }


### PR DESCRIPTION
Following #286 I changed the price text centering from `get_digits_even()` to use the proper `update_text_rect_to_center_str()` and finally removed `get_digits_even()`. This also consolidates the code for price printing and erasing rect to use the same function, making it more correct.
This also improves the centering for uneven number of characters, namely "$10" for Brainstorm and Blueprint

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/79a5db13-c2e6-4e75-aee6-a8504a62f127" />
