### PR TITLE
Fixed bug where the mult wasn't truncated

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -1022,7 +1022,7 @@ void display_chips(void)
     check_flaming_score();
 }
 
-void display_mult()
+void display_mult(void)
 {
     Rect mult_text_overflow_rect = MULT_TEXT_RECT;
     // In case of overflow the rect will overflow right by 1 char


### PR DESCRIPTION
There is a bug where the mult isn't truncated, seems like the change from #269 wasn't properly merged/rebased.

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/86bbc5b9-6746-4041-a0b5-bb4a66d6368b" />

I even have a picture on real hardware from a production build.
![20251215_103233](https://github.com/user-attachments/assets/0bc544dd-0244-405c-bcd3-78f9b0afd667)


This PR fixes the issue.