### PR TITLE
Fix url for nightly

### DIFF
--- a/.github/workflows/nightly_release_ci_workflow.yml
+++ b/.github/workflows/nightly_release_ci_workflow.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Deploy release
         uses: WebFreak001/deploy-nightly@v3.2.0
         with:
-          upload_url: https://uploads.github.com/repos/cellos51/balatro-gba/releases/258698380/assets{?name,label}
+          upload_url: https://uploads.github.com/repos/GBALATRO/balatro-gba/releases/258698380/assets{?name,label}
           release_id: 258698380
           asset_path: ./release.zip # path to archive to upload
           asset_name: nightly-gbalatro-$$.zip # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash


### PR DESCRIPTION
@MeirGavish Out nightly stopped working about a week ago, lol. It built fine, but was failing silently on uploading. I'm just going to merge this small change. 

The result of a successful run is here: https://github.com/GBALATRO/balatro-gba/actions/runs/20317023366/job/58363308770

~~I already deleted the release so it can do it correctly on it's own cadence.~~

---

**Edit**: I can't merge, but if you could before the next nightly, we should be good. If anything it's one more day without a nightly release. I'm going to re-run the workflow to get a release out in case someone wants the newest version. The last one in there is pretty stale.