### PR TITLE
Fixed incorrect swapped font mapping for .2 and .3

### DIFF
--- a/include/font.h
+++ b/include/font.h
@@ -32,8 +32,8 @@ extern const unsigned int gbalatro_sys8Glyphs[192];
  *  ```c
  *  '&' == '.0'
  *  '^' == '.1'
- *  '{' == '.2'
- *  '}' == '.3'
+ *  '}' == '.2'
+ *  '{' == '.3'
  *  '|' == '.4'
  *  '`' == '.5'
  *  '<' == '.6'
@@ -46,8 +46,8 @@ extern const unsigned int gbalatro_sys8Glyphs[192];
  */
 #define FP0_CHAR & // .0
 #define FP1_CHAR ^ // .1
-#define FP2_CHAR { // .2
-#define FP3_CHAR } // .3
+#define FP2_CHAR } // .2
+#define FP3_CHAR { // .3
 #define FP4_CHAR | // .4
 #define FP5_CHAR ` // .5
 #define FP6_CHAR < // .6


### PR DESCRIPTION
Leftovers from #314, the mapping for ".2" and ".3" was still incorrect.

```
tte_printf(
        "#{P:0,24; cx:0xF000}"
        "1234567890\n"
        XSTR(FP1_CHAR) XSTR(FP2_CHAR) XSTR(FP3_CHAR) XSTR(FP4_CHAR) XSTR(FP5_CHAR) XSTR(FP6_CHAR)
        XSTR(FP7_CHAR) XSTR(FP8_CHAR) XSTR(FP9_CHAR) XSTR(FP0_CHAR) "\n"
    );
```

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/ae84c072-4219-4440-8076-7b5ac1f1d132" />

@ricfehr3
I did it by swapping the characters rather than swapping in the font image itself, let me know if there's a reason it should be done the other way.