### PR TITLE
[Optimization] Slow down score lerping from 60 to 30 FPS

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -121,7 +121,8 @@
 /* This needs to stay a power of 2 and small enough
  * for the lerping to be done before the next hand is drawn.
  */
-#define NUM_SCORE_LERP_STEPS 32
+#define NUM_SCORE_LERP_STEPS   16
+#define TM_SCORE_LERP_INTERVAL 2
 
 // Shop
 #define REROLL_BASE_COST 5 // Base cost for rerolling the shop items
@@ -2984,7 +2985,7 @@ static inline void game_playing_process_input_and_state(void)
             );
         }
     }
-    else if (play_state == PLAY_ENDED)
+    else if (play_state == PLAY_ENDED && timer % FRAMES(TM_SCORE_LERP_INTERVAL) == 0)
     {
         /* Using fixed point in case the score is lower than NUM_SCORE_LERP_STEPS and then
          * then the division rounds it down to 0 and it's never added to the total.


### PR DESCRIPTION
Extracted and separated from #333.

Slowed score lerping so it happens every other frame instead of every frame. The idea was to give the CPU more time to render the score and avoid blank scores mid-lerping but this doesn't seem to make such a big difference in that regard.
I think it still looks good at this rate and maybe even better because you can better see the score accumulating?

Some videos to show the difference.

**Main**

https://github.com/user-attachments/assets/801b42df-1a23-48fe-b996-2d0b688d4c96


https://github.com/user-attachments/assets/28580cda-209c-4df6-9348-15a4010739aa

**PR**


https://github.com/user-attachments/assets/9854906b-abb0-447b-b940-f523de644e20

https://github.com/user-attachments/assets/7b4ffab6-15bd-45fc-b66b-7d24e49f7477


https://github.com/user-attachments/assets/8692b2a0-3f40-4e66-a373-ad3161d850f1


