### PR TITLE
Fixed Four Fingers bug #341, may be incorrect behavior though

### DIFF
--- a/include/hand_analysis.h
+++ b/include/hand_analysis.h
@@ -5,8 +5,23 @@
 
 #include <tonc.h>
 
-void get_hand_distribution(u8* ranks_out, u8* suits_out);
-void get_played_distribution(u8* ranks_out, u8* suits_out);
+/**
+ * @brief Outputs the distribution of ranks and suits in the hand
+ * @param ranks_out output - updated such as ranks_out[rank] is the number of cards of rank in the
+ *                  hand. Must be of size NUM_RANKS.
+ * @param suits_out output - updated such as suits_out[suit] is the number of cards if suit in the
+ *                  hand Must be of size NUM_SUITS
+ */
+void get_hand_distribution(u8 ranks_out[NUM_RANKS], u8 suits_out[NUM_SUITS]);
+
+/**
+ * @brief Outputs the distribution of ranks and suits in the played stack
+ * @param ranks_out output - updated such as ranks_out[rank] is the number of cards of rank in the
+ *                  played stack. Must be of size NUM_RANKS.
+ * @param suits_out output - updated such as suits_out[suit] is the number of cards if suit in the
+ *                  played stack. Must be of size NUM_SUITS
+ */
+void get_played_distribution(u8 ranks_out[NUM_RANKS], u8 suits_out[NUM_SUITS]);
 
 u8 hand_contains_n_of_a_kind(u8* ranks);
 bool hand_contains_two_pair(u8* ranks);

--- a/source/hand_analysis.c
+++ b/source/hand_analysis.c
@@ -3,18 +3,39 @@
 #include "card.h"
 #include "game.h"
 
-void get_hand_distribution(u8* ranks_out, u8* suits_out)
+
+/**
+ * @brief Outputs the distribution of ranks and suits in an input card array.
+ *        Can be unstaticed if needed (and then this comment moved to hand_analysis.h)
+ *        Can also be refactored to use list but then both the hand and played stack would
+ *        need to use list as well.
+ * @param cards     An array of CardObject pointers
+ * @param num_cards The number of elements in \p cards.
+ * @param ranks_out output - updated such as ranks_out[rank] is the number of cards of rank in
+ *                  \p cards. Must be of size NUM_RANKS.
+ * @param suits_out output - updated such as suits_out[suit] is the number of cards if suit in the
+ *                  \p cards. Must be of size NUM_SUITS.
+ */
+static inline void get_card_distribution(
+    CardObject** cards,
+    int num_cards,
+    u8 ranks_out[NUM_RANKS],
+    u8 suits_out[NUM_SUITS]
+)
 {
+    if (cards == NULL || ranks_out == NULL || suits_out == NULL)
+    {
+        return;
+    }
+
     for (int i = 0; i < NUM_RANKS; i++)
         ranks_out[i] = 0;
     for (int i = 0; i < NUM_SUITS; i++)
         suits_out[i] = 0;
 
-    CardObject** cards = get_hand_array();
-    int top = get_hand_top();
-    for (int i = 0; i <= top; i++)
+    for (int i = 0; i < num_cards; i++)
     {
-        if (cards[i] && card_object_is_selected(cards[i]))
+        if (cards[i] != NULL && card_object_is_selected(cards[i]))
         {
             ranks_out[cards[i]->card->rank]++;
             suits_out[cards[i]->card->suit]++;
@@ -22,22 +43,14 @@ void get_hand_distribution(u8* ranks_out, u8* suits_out)
     }
 }
 
-void get_played_distribution(u8* ranks_out, u8* suits_out)
+void get_hand_distribution(u8 ranks_out[NUM_RANKS], u8 suits_out[NUM_SUITS])
 {
-    for (int i = 0; i < NUM_RANKS; i++)
-        ranks_out[i] = 0;
-    for (int i = 0; i < NUM_SUITS; i++)
-        suits_out[i] = 0;
+    get_card_distribution(get_hand_array(), hand_get_size(), ranks_out, suits_out);
+}
 
-    CardObject** played = get_played_array();
-    int top = get_played_top();
-    for (int i = 0; i <= top; i++)
-    {
-        if (!played[i] || !card_object_is_selected(played[i]))
-            continue;
-        ranks_out[played[i]->card->rank]++;
-        suits_out[played[i]->card->suit]++;
-    }
+void get_played_distribution(u8 ranks_out[NUM_RANKS], u8 suits_out[NUM_SUITS])
+{
+    get_card_distribution(get_played_array(), get_played_top() + 1, ranks_out, suits_out);
 }
 
 // Returns the highest N of a kind. So a full-house would return 3.


### PR DESCRIPTION
This is a possible fix for the possible bug #341.
It seems like `cards_in_hand_update_loop()` in the `HAND_PLAY` section calls functions to set the scored cards in the played hand as `selected` so the fix would be to check if the cards are selected in the hand distribution function.
This does fix the bug and I didn't see any other errors so far but I need to re-review this fix and give it more testing for more hand types and cases since it touches a central function for hand detection. It also feels like there is a bit of an abuse of the `selected` flag but I guess a bigger refactor would be out of the scope for this fix.


https://github.com/user-attachments/assets/4cb942ca-ffb3-41fa-bef2-0055926805d6

Edit: so I extracted the seemingly duplicate code and did more testing and it seems to work as expected but apparently this behavior is [not in line with Balatro](https://github.com/GBALATRO/balatro-gba/issues/341#issuecomment-3691363488).
I might extract the documentation to another PR and not merge this one.


There's only one hand played here, I forgot the recording on, sorry about the video length.

https://github.com/user-attachments/assets/360025ac-8690-414d-b404-2b3742dd0564


https://github.com/user-attachments/assets/21b648de-e028-4a67-abea-32f74c6f57cd



https://github.com/user-attachments/assets/baa1af59-b71c-4ddf-aa61-1829c4b4605d

