### PR TITLE
Fix Four Fingers joker effect persisting after game over

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -564,7 +564,6 @@ static int discard_top = -1;
 static int shortcut_joker_count = 0;
 
 static int four_fingers_joker_count = 0;
-static int straight_and_flush_size = STRAIGHT_AND_FLUSH_SIZE_DEFAULT;
 
 GBAL_UNUSED
 static inline bool is_shop_joker_avail(int joker_id)
@@ -879,7 +878,8 @@ bool is_shortcut_joker_active(void)
 
 int get_straight_and_flush_size(void)
 {
-    return straight_and_flush_size;
+    return four_fingers_joker_count > 0 ? STRAIGHT_AND_FLUSH_SIZE_FOUR_FINGERS
+                                        : STRAIGHT_AND_FLUSH_SIZE_DEFAULT;
 }
 
 static void add_joker(JokerObject* joker_object)
@@ -891,10 +891,6 @@ static void add_joker(JokerObject* joker_object)
     // only change size when the first one is added
     if (joker_object->joker->id == FOUR_FINGERS_JOKER_ID)
     {
-        if (four_fingers_joker_count == 0)
-        {
-            straight_and_flush_size = STRAIGHT_AND_FLUSH_SIZE_FOUR_FINGERS;
-        }
         four_fingers_joker_count++;
     }
 
@@ -913,10 +909,6 @@ static void remove_owned_joker(int owned_joker_idx)
     if (joker_object->joker->id == FOUR_FINGERS_JOKER_ID)
     {
         four_fingers_joker_count--;
-        if (four_fingers_joker_count == 0)
-        {
-            straight_and_flush_size = STRAIGHT_AND_FLUSH_SIZE_DEFAULT;
-        }
     }
 
     if (joker_object->joker->id == SHORTCUT_JOKER_ID)
@@ -4791,8 +4783,8 @@ static void game_over_on_exit()
     while (list_get_len(&_owned_jokers_list) > 0)
     {
         JokerObject* joker_object = list_get_at_idx(&_owned_jokers_list, 0);
-        joker_object_destroy(&joker_object);
         remove_owned_joker(0);
+        joker_object_destroy(&joker_object);
     }
 
     tte_erase_screen();


### PR DESCRIPTION
When a run ended with Four Fingers owned, starting a new game would keep the straight/flush size at 4 instead of resetting to the default value of 5. This caused the Four Fingers effect to remain active even without the joker card.