### PR TITLE
Reset selection_y after skipping blind select

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -4507,6 +4507,8 @@ static void game_blind_select_handle_input()
             play_sfx(SFX_BUTTON, MM_BASE_PITCH_RATE, BUTTON_SFX_VOLUME);
             increment_blind(BLIND_STATE_SKIPPED);
 
+            selection_y = 0; // Reset selection to first option
+
             background = UNDEFINED; // Force refresh of the background
             change_background(BG_BLIND_SELECT);
 


### PR DESCRIPTION
This PR resets selection_y to 0 after skipping a blind, so the cursor hovers to select the next blind, instead of skipping it. This behaviour is in line with the original game.