### PR TITLE
Fix cards in deck count shifting when too few cards remain

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -404,7 +404,7 @@ static const Rect SINGLE_BLIND_SEL_REQ_SCORE_RECT = {80, 120,    104,     128  }
 // to be used with tte_erase_rect_wrapper()
 static const Rect HANDS_TEXT_RECT           = {16,      104,    UNDEFINED, UNDEFINED };
 static const Rect DISCARDS_TEXT_RECT        = {48,      104,    UNDEFINED, UNDEFINED };
-static const Rect DECK_SIZE_RECT            = {200,     152,    UNDEFINED, UNDEFINED };
+static const Rect DECK_SIZE_RECT            = {200,     152,    240,       160       };
 static const Rect ROUND_TEXT_RECT           = {48,      144,    UNDEFINED, UNDEFINED };
 static const Rect ANTE_TEXT_RECT            = {8,       144,    UNDEFINED, UNDEFINED };
 static const Rect ROUND_END_BLIND_REQ_RECT  = {104,     96,     136,       UNDEFINED };
@@ -3421,8 +3421,9 @@ static inline void game_playing_ui_text_update(void)
         }
 
         // Deck size/max size
+        tte_erase_rect_wrapper(DECK_SIZE_RECT);
         tte_printf(
-            "#{P:%d,%d; cx:0x%X000}%2d/%2d",
+            "#{P:%d,%d; cx:0x%X000}%d/%d",
             DECK_SIZE_RECT.left,
             DECK_SIZE_RECT.top,
             TTE_WHITE_PB,
@@ -4820,6 +4821,7 @@ static inline void game_start(void)
     change_background(BG_BLIND_SELECT);
 
     // Deck size/max size
+    tte_erase_rect_wrapper(DECK_SIZE_RECT);
     tte_printf(
         "#{P:%d,%d; cx:0x%X000}%d/%d",
         DECK_SIZE_RECT.left,

--- a/source/game.c
+++ b/source/game.c
@@ -3421,6 +3421,8 @@ static inline void game_playing_ui_text_update(void)
         }
 
         // Deck size/max size
+        // TODO: the text will overflow if deck max size exceeds 99,
+        // we will need a fix at some point for this
         tte_erase_rect_wrapper(DECK_SIZE_RECT);
         tte_printf(
             "#{P:%d,%d; cx:0x%X000}%d/%d",

--- a/source/game.c
+++ b/source/game.c
@@ -3422,7 +3422,7 @@ static inline void game_playing_ui_text_update(void)
 
         // Deck size/max size
         tte_printf(
-            "#{P:%d,%d; cx:0x%X000}%d/%d",
+            "#{P:%d,%d; cx:0x%X000}%2d/%2d",
             DECK_SIZE_RECT.left,
             DECK_SIZE_RECT.top,
             TTE_WHITE_PB,


### PR DESCRIPTION
Fix for issue #181 

The fix is assuming we will have no more than a 2 digits number of cards in our deck. This will need refactoring when deck fixing will be possible with Consumables but for now the deck is fixed at 52 cards