### PR TITLE
add profiler demo

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -21,6 +21,7 @@
 #include "audio_utils.h"
 #include "soundbank.h"
 #include "soundbank_bin.h"
+#include "tonc_core.h"
 
 void init()
 {
@@ -107,17 +108,55 @@ void draw()
     sprite_draw();
 }
 
+#define GBLATRO_PROFILE
+#ifdef GBLATRO_PROFILE
+
+// Add a breakpoint here in gdb, then `next` into the caller
+// function `profile_timer_stop` and `print` its variables
+static void profile_timer_breakpoint(void)
+{
+    static volatile u32 a;
+    (void)a;
+}
+
+static void profile_timer_stop(void)
+{
+    static volatile s32 prev_frame_time = 0;
+    static volatile s32 frame_time = 0;
+
+    frame_time = profile_stop();
+
+    volatile s32 frame_diff = frame_time - prev_frame_time;
+    (void)frame_diff;
+
+    // feel free to turn on, turns the game very slow
+    // tte_printf("#{P:0,0 ;x:0x2000} FRAME_TIME:       %ld", frame_time);
+    // tte_printf("#{P:0,8 ;x:0x2000} FRAME_TIME_PREV:  %ld", prev_frame_time);
+    // tte_printf("#{P:0,16;x:0x2000} FRAME_DIFF:      %ld", frame_diff);
+
+    profile_timer_breakpoint();
+
+    prev_frame_time = frame_time;
+}
+#endif
+
 int main()
 {
     init();
 
     while (true)
     {
+#ifdef GBLATRO_PROFILE
+        profile_start();
+#endif
         VBlankIntrWait();
         mmFrame();
         key_poll();
         update();
         draw();
+#ifdef GBLATRO_PROFILE
+        profile_timer_stop();
+#endif
     }
 
     return 0;


### PR DESCRIPTION
@MathisMartin31 @MeirGavish Sup guys. I stumbled across this simple profiler that comes built into tonc. `profile_start();` Starts the timer, `u32 time_passed = profile_stop();` stops the timer and returns the raw cycle count between calling `profile_start();` and `profile_stop()`. In the example below printing on the screen is very slow, so slow it makes the `frame_diff` variable unusable. However, if you use the function `profile_timer_breakpoint();` as a breakpoint, you can easily get the frame time differences with gdb. 

Not sure where this will be useful, but I thought I'd just let y'all and anyone else know.

This PR is just for discussion / example. Not going to be merged, at least not in this state.

[Doc link in tonc](https://www.coranac.com/man/tonclib/group__grpTimer.htm#ge8cb66eb4453b22b5eb31262c19517cc)