### PR TITLE
Changed the capitalization of hand names and centered them

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -507,19 +507,19 @@ static const int HAND_SPACING_LUT[MAX_HAND_SIZE] =
 
 static const HandValues hand_base_values[] = {
     {.chips = 0,   .mult = 0,  .display_name = NULL     }, // NONE
-    {.chips = 5,   .mult = 1,  .display_name = "HIGH C" }, // HIGH_CARD
-    {.chips = 10,  .mult = 2,  .display_name = "PAIR"   }, // PAIR
-    {.chips = 20,  .mult = 2,  .display_name = "2 PAIR" }, // TWO_PAIR
+    {.chips = 5,   .mult = 1,  .display_name = "Hi-Card"}, // HIGH_CARD
+    {.chips = 10,  .mult = 2,  .display_name = "Pair"   }, // PAIR
+    {.chips = 20,  .mult = 2,  .display_name = "2 Pair" }, // TWO_PAIR
     {.chips = 30,  .mult = 3,  .display_name = "3 OAK"  }, // THREE_OF_A_KIND
-    {.chips = 30,  .mult = 4,  .display_name = "STRT"   }, // STRAIGHT
-    {.chips = 35,  .mult = 4,  .display_name = "FLUSH"  }, // FLUSH
-    {.chips = 40,  .mult = 4,  .display_name = "FULL H" }, // FULL_HOUSE
+    {.chips = 30,  .mult = 4,  .display_name = "Strt"   }, // STRAIGHT
+    {.chips = 35,  .mult = 4,  .display_name = "Flush"  }, // FLUSH
+    {.chips = 40,  .mult = 4,  .display_name = "Full H" }, // FULL_HOUSE
     {.chips = 60,  .mult = 7,  .display_name = "4 OAK"  }, // FOUR_OF_A_KIND
-    {.chips = 100, .mult = 8,  .display_name = "STRT F" }, // STRAIGHT_FLUSH
-    {.chips = 100, .mult = 8,  .display_name = "ROYAL F"}, // ROYAL_FLUSH
+    {.chips = 100, .mult = 8,  .display_name = "Strt F" }, // STRAIGHT_FLUSH
+    {.chips = 100, .mult = 8,  .display_name = "Royal F"}, // ROYAL_FLUSH
     {.chips = 120, .mult = 12, .display_name = "5 OAK"  }, // FIVE_OF_A_KIND
-    {.chips = 140, .mult = 14, .display_name = "FLUSH H"}, // FLUSH_HOUSE
-    {.chips = 160, .mult = 16, .display_name = "FLUSH 5"}  // FLUSH_FIVE
+    {.chips = 140, .mult = 14, .display_name = "Flush H"}, // FLUSH_HOUSE
+    {.chips = 160, .mult = 16, .display_name = "Flush 5"}  // FLUSH_FIVE
 };
 
 static const SubStateActionFn shop_state_actions[] = {
@@ -1839,10 +1839,13 @@ static void print_hand_type(const char* hand_type_str)
 {
     if (hand_type_str == NULL)
         return; // NULL-checking paranoia
+
+    Rect hand_type_rect = HAND_TYPE_RECT;
+    update_text_rect_to_center_str(&hand_type_rect, hand_type_str, SCREEN_LEFT);
     tte_printf(
         "#{P:%d,%d; cx:0x%X000}%s",
-        HAND_TYPE_RECT.left,
-        HAND_TYPE_RECT.top,
+        hand_type_rect.left,
+        hand_type_rect.top,
         TTE_WHITE_PB,
         hand_type_str
     );


### PR DESCRIPTION
I changed the capitalization of the hand names from all-caps to title case since that's what it's like in Balatro. I also centered the text in the box.
I also changed the abbreviation "High C" into "Hi-Card", I think it looks nicer and is more readable and it derives from the recognizable "Hi-Score".
I also kept "3/4 OAK" capitalized to indicate it's an acronym.

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/b82b9e7c-07c4-4e02-8f5f-916ef4007f6e" />

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/0df29dfa-9790-4bd8-9fdf-fac2c5ddea9c" />

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/fd51483b-76c9-4de6-9033-12ca34e95142" />

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/65c7c790-bf96-4cc7-a6d2-d51e4c80a835" />

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/4c016818-8256-47f2-9373-aadc87823374" />

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/08ac3666-7bd4-4d6f-85cc-29389236622d" />

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/298113b2-01ad-4bcb-ada3-7775e6fa6529" />
