### PR TITLE
Fixed Shortcut joker ID for #410

### DIFF
--- a/include/joker.h
+++ b/include/joker.h
@@ -84,10 +84,8 @@ enum JokerEvent
 #define MAX_JOKER_OBJECTS 32 // The maximum number of joker objects that can be created at once
 
 // Jokers in the game
-#define DEFAULT_JOKER_ID      0
 #define STENCIL_JOKER_ID      15
-#define GREEDY_JOKER_ID       18
-#define SHORTCUT_JOKER_ID     38
+#define SHORTCUT_JOKER_ID     48
 #define BRAINSTORM_JOKER_ID   41
 #define PAREIDOLIA_JOKER_ID   46
 #define FOUR_FINGERS_JOKER_ID 50


### PR DESCRIPTION
closes #410
It seems `SHORTCUT_JOKER_ID` was just not up to date.
I also removed some unused joker IDs.

<img width="240" height="160" alt="balatro-gba-11" src="https://github.com/user-attachments/assets/0c5a8230-0916-4d2d-998d-e4f249cada18" />
<img width="240" height="160" alt="balatro-gba-12" src="https://github.com/user-attachments/assets/0c3b33b3-c1df-4c89-b350-8b80088dd3f0" />
<img width="240" height="160" alt="balatro-gba-13" src="https://github.com/user-attachments/assets/cae32145-d3ca-49df-95de-253169d4369a" />
