### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/build_ci_workflow.yml
+++ b/.github/workflows/build_ci_workflow.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get docker image cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/docker-cache
           key: docker-images-${{ hashFiles('docker-compose.yml') }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: 'Upload Artifact'
         if: ${{ inputs.upload-build-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-out
           path: build

--- a/.github/workflows/clang_format_ci_workflow.yml
+++ b/.github/workflows/clang_format_ci_workflow.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-format
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run clang-format
         run: clang-format --dry-run -Werror include/*.h source/*.c

--- a/.github/workflows/nightly_release_ci_workflow.yml
+++ b/.github/workflows/nightly_release_ci_workflow.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the build output
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-out
           path: build

--- a/.github/workflows/tagged_release_ci_workflow.yml
+++ b/.github/workflows/tagged_release_ci_workflow.yml
@@ -18,7 +18,7 @@ jobs:
     needs: build-job
     steps:
       - name: Download the build output
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-out
           path: build

--- a/.github/workflows/unit_tests_ci_workflow.yml
+++ b/.github/workflows/unit_tests_ci_workflow.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check and install GCC version
         run: ./ci_scripts/check_gcc_version.sh


### PR DESCRIPTION
Update github actions versions to remove the Node version warnings going forward.

Warnings like these are in our CI:

<img width="998" height="177" alt="image" src="https://github.com/user-attachments/assets/a1ea40aa-f93a-4c7f-bd2c-dcee16442894" />

This attempts to fix these warnings by updating everything to its newest version.