### PR TITLE
feat: implement 7 boss blind effects (The Needle, Water, Hook, Psychic, Tooth, Eye, Ox)

### DIFF
--- a/include/boss_blind_effects.h
+++ b/include/boss_blind_effects.h
@@ -3,17 +3,19 @@
  *
  * @brief Boss blind effect definitions and API.
  *
- * Each ante (1–7) has a distinct boss blind with a unique gameplay modifier.
- * Antes beyond 7 cycle back to the first boss blind (The Needle).
+ * The active boss blind is identified by the game''s current_blind variable
+ * (enum BlindType from blind.h). All functions in this module take a
+ * BlindType directly; callers pass current_blind instead of calling the
+ * removed boss_blind_get_for_ante() helper.
  *
  * Implemented boss blinds:
- *   Ante 1 – The Needle  : Only 1 hand allowed per round.
- *   Ante 2 – The Water   : Start the round with 0 discards.
- *   Ante 3 – The Hook    : After each hand scored, 2 held cards are discarded.
- *   Ante 4 – The Psychic : Must play exactly 5 cards.
- *   Ante 5 – The Tooth   : Lose $1 for each card played.
- *   Ante 6 – The Eye     : Each hand type can only be played once per round.
- *   Ante 7 – The Ox      : Playing any hand sets money to $0.
+ *   The Needle  : Only 1 hand allowed per round.
+ *   The Water   : Start the round with 0 discards.
+ *   The Hook    : After each hand scored, 2 held cards are discarded.
+ *   The Psychic : Must play exactly 5 cards.
+ *   The Tooth   : Lose $1 for each card played.
+ *   The Eye     : Each hand type can only be played once per round.
+ *   The Ox      : Playing any hand sets money to $0.
  */
 
 #ifndef BOSS_BLIND_EFFECTS_H
@@ -21,106 +23,17 @@
 
 #include <stdbool.h>
 
+#include `"blind.h`"
+
 /** Maximum number of distinct hand types (matches enum HandType in game.h). */
 #define BOSS_BLIND_MAX_HAND_TYPES 14
 
-/**
- * @brief Identifies which boss blind effect is active.
- * Assigned deterministically: boss_blind_get_for_ante(ante) returns
- * (ante - 1) % BOSS_BLIND_ID_MAX.
- */
-enum BossBlindId
-{
-    BOSS_THE_NEEDLE = 0,  /**< Only 1 hand allowed.                          */
-    BOSS_THE_WATER = 1,   /**< Start with 0 discards.                        */
-    BOSS_THE_HOOK = 2,    /**< Discard 2 held cards after each hand scored.  */
-    BOSS_THE_PSYCHIC = 3, /**< Must play exactly 5 cards.                    */
-    BOSS_THE_TOOTH = 4,   /**< Lose $1 per card played.                      */
-    BOSS_THE_EYE = 5,     /**< Each hand type playable only once per round.  */
-    BOSS_THE_OX = 6,      /**< Playing any hand sets money to $0.            */
-    BOSS_BLIND_ID_MAX     /**< Sentinel – do not use as a boss blind ID.     */
-};
-
-/**
- * @brief Returns the boss blind active for the given ante (1-based).
- *        Cycles when ante exceeds BOSS_BLIND_ID_MAX.
- *
- * @param ante  Current ante number (>= 1).
- * @return      Active boss blind ID.
- */
-enum BossBlindId boss_blind_get_for_ante(int ante);
-
-/**
- * @brief Applies round-start stat modifications for the active boss blind.
- *        Call once at the start of a boss blind round, before displaying
- *        hands/discards counts.
- *
- * @param id        Active boss blind ID.
- * @param hands     Pointer to the current hands-remaining counter.
- * @param discards  Pointer to the current discards-remaining counter.
- * @param hand_size Pointer to the current hand size.
- */
-void boss_blind_apply_round_start(enum BossBlindId id, int* hands, int* discards, int* hand_size);
-
-/**
- * @brief Validates whether playing the current selection is allowed.
- *        Returns false if the boss blind forbids the action.
- *
- * @param id              Active boss blind ID.
- * @param hand_selections Number of currently selected cards.
- * @param hand_type       Current hand type (cast from enum HandType).
- * @return                true if the play is allowed.
- */
-bool boss_blind_validate_play(enum BossBlindId id, int hand_selections, int hand_type);
-
-/**
- * @brief Returns how many random held cards should be discarded after scoring.
- *        Non-zero only for The Hook (returns 2).
- *
- * @param id  Active boss blind ID.
- * @return    Number of cards to discard (0 or 2).
- */
-int boss_blind_get_hook_count(enum BossBlindId id);
-
-/**
- * @brief Returns the money penalty after playing a hand.
- *        Non-zero only for The Tooth ($1 per card played).
- *
- * @param id           Active boss blind ID.
- * @param cards_played Number of cards played this hand.
- * @return             Money to deduct (>= 0).
- */
-int boss_blind_get_tooth_penalty(enum BossBlindId id, int cards_played);
-
-/**
- * @brief Returns true if playing any hand should drain money to $0 (The Ox).
- *
- * @param id  Active boss blind ID.
- * @return    true for The Ox, false otherwise.
- */
-bool boss_blind_is_ox_active(enum BossBlindId id);
-
-/**
- * @brief Records that a hand type has been played this round.
- *        Used by The Eye to track which types are exhausted.
- *
- * @param id         Active boss blind ID.
- * @param hand_type  Hand type that was just played (cast from enum HandType).
- */
-void boss_blind_register_hand(enum BossBlindId id, int hand_type);
-
-/**
- * @brief Resets all per-round boss blind state (e.g. The Eye's played-types
- *        bitfield). Call at the start of each boss blind round.
- */
+void boss_blind_apply_round_start(enum BlindType id, int* hands, int* discards, int* hand_size);
+bool boss_blind_validate_play(enum BlindType id, int hand_selections, int hand_type);
+int boss_blind_get_hook_count(enum BlindType id);
+int boss_blind_get_tooth_penalty(enum BlindType id, int cards_played);
+bool boss_blind_is_ox_active(enum BlindType id);
+void boss_blind_register_hand(enum BlindType id, int hand_type);
 void boss_blind_reset(void);
-
-/**
- * @brief Returns the display name for a boss blind.
- *
- * @param id  Boss blind ID.
- * @return    Null-terminated display string, never NULL.
- */
-const char* boss_blind_get_name(enum BossBlindId id);
 
 #endif // BOSS_BLIND_EFFECTS_H

--- a/include/boss_blind_effects.h
+++ b/include/boss_blind_effects.h
@@ -23,7 +23,7 @@
 
 #include <stdbool.h>
 
-#include `"blind.h`"
+#include "blind.h"
 
 /** Maximum number of distinct hand types (matches enum HandType in game.h). */
 #define BOSS_BLIND_MAX_HAND_TYPES 14

--- a/include/boss_blind_effects.h
+++ b/include/boss_blind_effects.h
@@ -1,0 +1,135 @@
+/**
+ * @file boss_blind_effects.h
+ *
+ * @brief Boss blind effect definitions and API.
+ *
+ * Each ante (1–7) has a distinct boss blind with a unique gameplay modifier.
+ * Antes beyond 7 cycle back to the first boss blind (The Needle).
+ *
+ * Implemented boss blinds:
+ *   Ante 1 – The Needle  : Only 1 hand allowed per round.
+ *   Ante 2 – The Water   : Start the round with 0 discards.
+ *   Ante 3 – The Hook    : After each hand scored, 2 held cards are discarded.
+ *   Ante 4 – The Psychic : Must play exactly 5 cards.
+ *   Ante 5 – The Tooth   : Lose $1 for each card played.
+ *   Ante 6 – The Eye     : Each hand type can only be played once per round.
+ *   Ante 7 – The Ox      : Playing any hand sets money to $0.
+ */
+
+#ifndef BOSS_BLIND_EFFECTS_H
+#define BOSS_BLIND_EFFECTS_H
+
+#include <stdbool.h>
+
+/** Maximum number of distinct hand types (matches enum HandType in game.h). */
+#define BOSS_BLIND_MAX_HAND_TYPES 14
+
+/**
+ * @brief Identifies which boss blind effect is active.
+ * Assigned deterministically: boss_blind_get_for_ante(ante) returns
+ * (ante - 1) % BOSS_BLIND_ID_MAX.
+ */
+enum BossBlindId
+{
+    BOSS_THE_NEEDLE  = 0, /**< Only 1 hand allowed.                          */
+    BOSS_THE_WATER   = 1, /**< Start with 0 discards.                        */
+    BOSS_THE_HOOK    = 2, /**< Discard 2 held cards after each hand scored.  */
+    BOSS_THE_PSYCHIC = 3, /**< Must play exactly 5 cards.                    */
+    BOSS_THE_TOOTH   = 4, /**< Lose $1 per card played.                      */
+    BOSS_THE_EYE     = 5, /**< Each hand type playable only once per round.  */
+    BOSS_THE_OX      = 6, /**< Playing any hand sets money to $0.            */
+    BOSS_BLIND_ID_MAX     /**< Sentinel – do not use as a boss blind ID.     */
+};
+
+/**
+ * @brief Returns the boss blind active for the given ante (1-based).
+ *        Cycles when ante exceeds BOSS_BLIND_ID_MAX.
+ *
+ * @param ante  Current ante number (>= 1).
+ * @return      Active boss blind ID.
+ */
+enum BossBlindId boss_blind_get_for_ante(int ante);
+
+/**
+ * @brief Applies round-start stat modifications for the active boss blind.
+ *        Call once at the start of a boss blind round, before displaying
+ *        hands/discards counts.
+ *
+ * @param id        Active boss blind ID.
+ * @param hands     Pointer to the current hands-remaining counter.
+ * @param discards  Pointer to the current discards-remaining counter.
+ * @param hand_size Pointer to the current hand size.
+ */
+void boss_blind_apply_round_start(
+    enum BossBlindId id,
+    int*             hands,
+    int*             discards,
+    int*             hand_size
+);
+
+/**
+ * @brief Validates whether playing the current selection is allowed.
+ *        Returns false if the boss blind forbids the action.
+ *
+ * @param id              Active boss blind ID.
+ * @param hand_selections Number of currently selected cards.
+ * @param hand_type       Current hand type (cast from enum HandType).
+ * @return                true if the play is allowed.
+ */
+bool boss_blind_validate_play(
+    enum BossBlindId id,
+    int              hand_selections,
+    int              hand_type
+);
+
+/**
+ * @brief Returns how many random held cards should be discarded after scoring.
+ *        Non-zero only for The Hook (returns 2).
+ *
+ * @param id  Active boss blind ID.
+ * @return    Number of cards to discard (0 or 2).
+ */
+int boss_blind_get_hook_count(enum BossBlindId id);
+
+/**
+ * @brief Returns the money penalty after playing a hand.
+ *        Non-zero only for The Tooth ($1 per card played).
+ *
+ * @param id           Active boss blind ID.
+ * @param cards_played Number of cards played this hand.
+ * @return             Money to deduct (>= 0).
+ */
+int boss_blind_get_tooth_penalty(enum BossBlindId id, int cards_played);
+
+/**
+ * @brief Returns true if playing any hand should drain money to $0 (The Ox).
+ *
+ * @param id  Active boss blind ID.
+ * @return    true for The Ox, false otherwise.
+ */
+bool boss_blind_is_ox_active(enum BossBlindId id);
+
+/**
+ * @brief Records that a hand type has been played this round.
+ *        Used by The Eye to track which types are exhausted.
+ *
+ * @param id         Active boss blind ID.
+ * @param hand_type  Hand type that was just played (cast from enum HandType).
+ */
+void boss_blind_register_hand(enum BossBlindId id, int hand_type);
+
+/**
+ * @brief Resets all per-round boss blind state (e.g. The Eye's played-types
+ *        bitfield). Call at the start of each boss blind round.
+ */
+void boss_blind_reset(void);
+
+/**
+ * @brief Returns the display name for a boss blind.
+ *
+ * @param id  Boss blind ID.
+ * @return    Null-terminated display string, never NULL.
+ */
+const char* boss_blind_get_name(enum BossBlindId id);
+
+#endif // BOSS_BLIND_EFFECTS_H

--- a/include/boss_blind_effects.h
+++ b/include/boss_blind_effects.h
@@ -31,13 +31,13 @@
  */
 enum BossBlindId
 {
-    BOSS_THE_NEEDLE  = 0, /**< Only 1 hand allowed.                          */
-    BOSS_THE_WATER   = 1, /**< Start with 0 discards.                        */
-    BOSS_THE_HOOK    = 2, /**< Discard 2 held cards after each hand scored.  */
+    BOSS_THE_NEEDLE = 0,  /**< Only 1 hand allowed.                          */
+    BOSS_THE_WATER = 1,   /**< Start with 0 discards.                        */
+    BOSS_THE_HOOK = 2,    /**< Discard 2 held cards after each hand scored.  */
     BOSS_THE_PSYCHIC = 3, /**< Must play exactly 5 cards.                    */
-    BOSS_THE_TOOTH   = 4, /**< Lose $1 per card played.                      */
-    BOSS_THE_EYE     = 5, /**< Each hand type playable only once per round.  */
-    BOSS_THE_OX      = 6, /**< Playing any hand sets money to $0.            */
+    BOSS_THE_TOOTH = 4,   /**< Lose $1 per card played.                      */
+    BOSS_THE_EYE = 5,     /**< Each hand type playable only once per round.  */
+    BOSS_THE_OX = 6,      /**< Playing any hand sets money to $0.            */
     BOSS_BLIND_ID_MAX     /**< Sentinel – do not use as a boss blind ID.     */
 };
 
@@ -60,12 +60,7 @@ enum BossBlindId boss_blind_get_for_ante(int ante);
  * @param discards  Pointer to the current discards-remaining counter.
  * @param hand_size Pointer to the current hand size.
  */
-void boss_blind_apply_round_start(
-    enum BossBlindId id,
-    int*             hands,
-    int*             discards,
-    int*             hand_size
-);
+void boss_blind_apply_round_start(enum BossBlindId id, int* hands, int* discards, int* hand_size);
 
 /**
  * @brief Validates whether playing the current selection is allowed.
@@ -76,11 +71,7 @@ void boss_blind_apply_round_start(
  * @param hand_type       Current hand type (cast from enum HandType).
  * @return                true if the play is allowed.
  */
-bool boss_blind_validate_play(
-    enum BossBlindId id,
-    int              hand_selections,
-    int              hand_type
-);
+bool boss_blind_validate_play(enum BossBlindId id, int hand_selections, int hand_type);
 
 /**
  * @brief Returns how many random held cards should be discarded after scoring.

--- a/source/boss_blind_effects.c
+++ b/source/boss_blind_effects.c
@@ -3,7 +3,7 @@
  * @brief Boss blind effect implementations.
  */
 
-#include boss_blind_effects.h
+#include "boss_blind_effects.h"
 
 static bool s_eye_played_types[BOSS_BLIND_MAX_HAND_TYPES];
 

--- a/source/boss_blind_effects.c
+++ b/source/boss_blind_effects.c
@@ -38,12 +38,7 @@ enum BossBlindId boss_blind_get_for_ante(int ante)
     return (enum BossBlindId)((ante - 1) % (int)BOSS_BLIND_ID_MAX);
 }
 
-void boss_blind_apply_round_start(
-    enum BossBlindId id,
-    int*             hands,
-    int*             discards,
-    int*             hand_size
-)
+void boss_blind_apply_round_start(enum BossBlindId id, int* hands, int* discards, int* hand_size)
 {
     (void)hand_size; /* reserved for future use (e.g. The Manacle) */
 
@@ -65,11 +60,7 @@ void boss_blind_apply_round_start(
     }
 }
 
-bool boss_blind_validate_play(
-    enum BossBlindId id,
-    int              hand_selections,
-    int              hand_type
-)
+bool boss_blind_validate_play(enum BossBlindId id, int hand_selections, int hand_type)
 {
     switch (id)
     {

--- a/source/boss_blind_effects.c
+++ b/source/boss_blind_effects.c
@@ -1,104 +1,63 @@
 /**
  * @file boss_blind_effects.c
- *
  * @brief Boss blind effect implementations.
- *
- * See boss_blind_effects.h for full documentation.
  */
 
-#include "boss_blind_effects.h"
+#include boss_blind_effects.h
 
-/* ── Internal state ────────────────────────────────────────────────────── */
-
-/**
- * Tracks which hand types have been played this round (for The Eye).
- * Indexed by int hand_type value (0 = NONE, 1 = HIGH_CARD, …).
- * Reset by boss_blind_reset().
- */
 static bool s_eye_played_types[BOSS_BLIND_MAX_HAND_TYPES];
 
-/* ── Name table ─────────────────────────────────────────────────────────── */
-
-static const char* const s_boss_names[BOSS_BLIND_ID_MAX] = {
-    "The Needle",  /* BOSS_THE_NEEDLE  */
-    "The Water",   /* BOSS_THE_WATER   */
-    "The Hook",    /* BOSS_THE_HOOK    */
-    "The Psychic", /* BOSS_THE_PSYCHIC */
-    "The Tooth",   /* BOSS_THE_TOOTH   */
-    "The Eye",     /* BOSS_THE_EYE     */
-    "The Ox",      /* BOSS_THE_OX      */
-};
-
-/* ── Public API ─────────────────────────────────────────────────────────── */
-
-enum BossBlindId boss_blind_get_for_ante(int ante)
+void boss_blind_apply_round_start(enum BlindType id, int* hands, int* discards, int* hand_size)
 {
-    if (ante < 1)
-        ante = 1;
-    return (enum BossBlindId)((ante - 1) % (int)BOSS_BLIND_ID_MAX);
-}
-
-void boss_blind_apply_round_start(enum BossBlindId id, int* hands, int* discards, int* hand_size)
-{
-    (void)hand_size; /* reserved for future use (e.g. The Manacle) */
-
+    (void)hand_size;
     switch (id)
     {
-        case BOSS_THE_NEEDLE:
-            /* Only 1 hand allowed – overwrite however many were reset. */
+        case BLIND_TYPE_NEEDLE:
             *hands = 1;
             break;
-
-        case BOSS_THE_WATER:
-            /* No discards available this round. */
+        case BLIND_TYPE_WATER:
             *discards = 0;
             break;
-
         default:
-            /* Other boss blinds have no round-start stat modification. */
             break;
     }
 }
 
-bool boss_blind_validate_play(enum BossBlindId id, int hand_selections, int hand_type)
+bool boss_blind_validate_play(enum BlindType id, int hand_selections, int hand_type)
 {
     switch (id)
     {
-        case BOSS_THE_PSYCHIC:
-            /* Must select exactly 5 cards before playing. */
+        case BLIND_TYPE_PSYCHIC:
             return hand_selections == 5;
-
-        case BOSS_THE_EYE:
-            /* Reject if this hand type has already been played this round. */
+        case BLIND_TYPE_EYE:
             if (hand_type >= 0 && hand_type < BOSS_BLIND_MAX_HAND_TYPES)
                 return !s_eye_played_types[hand_type];
             return true;
-
         default:
             return true;
     }
 }
 
-int boss_blind_get_hook_count(enum BossBlindId id)
+int boss_blind_get_hook_count(enum BlindType id)
 {
-    return (id == BOSS_THE_HOOK) ? 2 : 0;
+    return (id == BLIND_TYPE_HOOK) ? 2 : 0;
 }
 
-int boss_blind_get_tooth_penalty(enum BossBlindId id, int cards_played)
+int boss_blind_get_tooth_penalty(enum BlindType id, int cards_played)
 {
-    if (id == BOSS_THE_TOOTH && cards_played > 0)
-        return cards_played; /* $1 per card played */
+    if (id == BLIND_TYPE_TOOTH && cards_played > 0)
+        return cards_played;
     return 0;
 }
 
-bool boss_blind_is_ox_active(enum BossBlindId id)
+bool boss_blind_is_ox_active(enum BlindType id)
 {
-    return id == BOSS_THE_OX;
+    return id == BLIND_TYPE_OX;
 }
 
-void boss_blind_register_hand(enum BossBlindId id, int hand_type)
+void boss_blind_register_hand(enum BlindType id, int hand_type)
 {
-    if (id == BOSS_THE_EYE && hand_type >= 0 && hand_type < BOSS_BLIND_MAX_HAND_TYPES)
+    if (id == BLIND_TYPE_EYE && hand_type >= 0 && hand_type < BOSS_BLIND_MAX_HAND_TYPES)
         s_eye_played_types[hand_type] = true;
 }
 
@@ -106,11 +65,4 @@ void boss_blind_reset(void)
 {
     for (int i = 0; i < BOSS_BLIND_MAX_HAND_TYPES; i++)
         s_eye_played_types[i] = false;
-}
-
-const char* boss_blind_get_name(enum BossBlindId id)
-{
-    if (id < 0 || id >= BOSS_BLIND_ID_MAX)
-        return "Boss Blind";
-    return s_boss_names[id];
 }

--- a/source/boss_blind_effects.c
+++ b/source/boss_blind_effects.c
@@ -1,0 +1,125 @@
+/**
+ * @file boss_blind_effects.c
+ *
+ * @brief Boss blind effect implementations.
+ *
+ * See boss_blind_effects.h for full documentation.
+ */
+
+#include "boss_blind_effects.h"
+
+/* ── Internal state ────────────────────────────────────────────────────── */
+
+/**
+ * Tracks which hand types have been played this round (for The Eye).
+ * Indexed by int hand_type value (0 = NONE, 1 = HIGH_CARD, …).
+ * Reset by boss_blind_reset().
+ */
+static bool s_eye_played_types[BOSS_BLIND_MAX_HAND_TYPES];
+
+/* ── Name table ─────────────────────────────────────────────────────────── */
+
+static const char* const s_boss_names[BOSS_BLIND_ID_MAX] = {
+    "The Needle",  /* BOSS_THE_NEEDLE  */
+    "The Water",   /* BOSS_THE_WATER   */
+    "The Hook",    /* BOSS_THE_HOOK    */
+    "The Psychic", /* BOSS_THE_PSYCHIC */
+    "The Tooth",   /* BOSS_THE_TOOTH   */
+    "The Eye",     /* BOSS_THE_EYE     */
+    "The Ox",      /* BOSS_THE_OX      */
+};
+
+/* ── Public API ─────────────────────────────────────────────────────────── */
+
+enum BossBlindId boss_blind_get_for_ante(int ante)
+{
+    if (ante < 1)
+        ante = 1;
+    return (enum BossBlindId)((ante - 1) % (int)BOSS_BLIND_ID_MAX);
+}
+
+void boss_blind_apply_round_start(
+    enum BossBlindId id,
+    int*             hands,
+    int*             discards,
+    int*             hand_size
+)
+{
+    (void)hand_size; /* reserved for future use (e.g. The Manacle) */
+
+    switch (id)
+    {
+        case BOSS_THE_NEEDLE:
+            /* Only 1 hand allowed – overwrite however many were reset. */
+            *hands = 1;
+            break;
+
+        case BOSS_THE_WATER:
+            /* No discards available this round. */
+            *discards = 0;
+            break;
+
+        default:
+            /* Other boss blinds have no round-start stat modification. */
+            break;
+    }
+}
+
+bool boss_blind_validate_play(
+    enum BossBlindId id,
+    int              hand_selections,
+    int              hand_type
+)
+{
+    switch (id)
+    {
+        case BOSS_THE_PSYCHIC:
+            /* Must select exactly 5 cards before playing. */
+            return hand_selections == 5;
+
+        case BOSS_THE_EYE:
+            /* Reject if this hand type has already been played this round. */
+            if (hand_type >= 0 && hand_type < BOSS_BLIND_MAX_HAND_TYPES)
+                return !s_eye_played_types[hand_type];
+            return true;
+
+        default:
+            return true;
+    }
+}
+
+int boss_blind_get_hook_count(enum BossBlindId id)
+{
+    return (id == BOSS_THE_HOOK) ? 2 : 0;
+}
+
+int boss_blind_get_tooth_penalty(enum BossBlindId id, int cards_played)
+{
+    if (id == BOSS_THE_TOOTH && cards_played > 0)
+        return cards_played; /* $1 per card played */
+    return 0;
+}
+
+bool boss_blind_is_ox_active(enum BossBlindId id)
+{
+    return id == BOSS_THE_OX;
+}
+
+void boss_blind_register_hand(enum BossBlindId id, int hand_type)
+{
+    if (id == BOSS_THE_EYE && hand_type >= 0 && hand_type < BOSS_BLIND_MAX_HAND_TYPES)
+        s_eye_played_types[hand_type] = true;
+}
+
+void boss_blind_reset(void)
+{
+    for (int i = 0; i < BOSS_BLIND_MAX_HAND_TYPES; i++)
+        s_eye_played_types[i] = false;
+}
+
+const char* boss_blind_get_name(enum BossBlindId id)
+{
+    if (id < 0 || id >= BOSS_BLIND_ID_MAX)
+        return "Boss Blind";
+    return s_boss_names[id];
+}

--- a/source/game.c
+++ b/source/game.c
@@ -9,6 +9,7 @@
 #include "background_shop_gfx.h"
 #include "bitset.h"
 #include "blind.h"
+#include "boss_blind_effects.h"
 #include "button.h"
 #include "card.h"
 #include "game/common_ui.h"
@@ -1974,6 +1975,18 @@ static void game_round_on_init(GameVariables* vars)
 
     deck_shuffle(); // Shuffle the deck at the start of the round
 
+    // Apply boss blind round-start modifications (hand / discard counts).
+    // These run after game_round_end_cashout() has already reset hands and
+    // discards to their maximums, so overwriting them here is intentional.
+    if (current_blind == BLIND_TYPE_BOSS)
+    {
+        enum BossBlindId boss_id = boss_blind_get_for_ante(ante);
+        boss_blind_reset();
+        boss_blind_apply_round_start(boss_id, &hands, &discards, &hand_size);
+        display_hands(hands);
+        display_discards(discards);
+    }
+
     /* Note that since cards_in_hand_update_loop() handles card highlight there's no need
      * to call a selection changed callback to highlight the initial card, this wouldn't work
      * otherwise or for the buttons.
@@ -2291,6 +2304,12 @@ static bool can_play_hand(void)
 {
     if (hand_state != HAND_SELECT || hand_selections == 0)
         return false;
+
+    // Boss blind play restrictions (The Psychic: exactly 5 cards; The Eye: no repeated hand types)
+    if (current_blind == BLIND_TYPE_BOSS &&
+        !boss_blind_validate_play(boss_blind_get_for_ante(ante), hand_selections, (int)hand_type))
+        return false;
+
     return true;
 }
 
@@ -2720,6 +2739,50 @@ static bool play_ended_played_cards_update(int played_idx)
             // we reached hand_top, all cards have been discarded
             if (played_idx == played_top)
             {
+                // ── Boss blind post-hand effects ──────────────────────────
+                // These run before played_top is reset so we still know the
+                // number of cards that were played this hand.
+                if (current_blind == BLIND_TYPE_BOSS)
+                {
+                    enum BossBlindId boss_id  = boss_blind_get_for_ante(ante);
+                    int              n_played = played_top + 1;
+
+                    // The Eye: record the hand type so it cannot be played again.
+                    boss_blind_register_hand(boss_id, (int)hand_type);
+
+                    // The Tooth: lose $1 per card played.
+                    int penalty = boss_blind_get_tooth_penalty(boss_id, n_played);
+                    if (penalty > 0)
+                    {
+                        money = (money > penalty) ? money - penalty : 0;
+                        display_money();
+                    }
+
+                    // The Ox: playing any hand drains money to $0.
+                    if (boss_blind_is_ox_active(boss_id))
+                    {
+                        money = 0;
+                        display_money();
+                    }
+
+                    // The Hook: discard the 2 topmost held cards.
+                    // TODO: Animate the removal using the HAND_DISCARD state
+                    //       and randomise which cards are chosen.
+                    int hook_count = boss_blind_get_hook_count(boss_id);
+                    for (int bh = 0; bh < hook_count; bh++)
+                    {
+                        // Skip any NULL slots left by previously played cards.
+                        while (hand_top >= 0 && hand[hand_top] == NULL)
+                            hand_top--;
+                        if (hand_top < 0)
+                            break;
+                        discard_push(hand[hand_top]->card);
+                        card_object_destroy(&hand[hand_top]);
+                        hand_top--;
+                    }
+                }
+                // ─────────────────────────────────────────────────────────
+
                 if (game_round_is_over())
                 {
                     hand_state = HAND_SHUFFLING;

--- a/source/game.c
+++ b/source/game.c
@@ -2744,8 +2744,8 @@ static bool play_ended_played_cards_update(int played_idx)
                 // number of cards that were played this hand.
                 if (current_blind == BLIND_TYPE_BOSS)
                 {
-                    enum BossBlindId boss_id  = boss_blind_get_for_ante(ante);
-                    int              n_played = played_top + 1;
+                    enum BossBlindId boss_id = boss_blind_get_for_ante(ante);
+                    int n_played = played_top + 1;
 
                     // The Eye: record the hand type so it cannot be played again.
                     boss_blind_register_hand(boss_id, (int)hand_type);
@@ -3836,8 +3836,10 @@ static inline void game_round_end_print_interest_reward(int interest_y_offset)
         );
     }
     // Increment the interest reward text until the interest reward variable is depleted
-    else if (timer > interest_start_time + TM_REWARD_DISPLAY_INTERVAL &&
-             timer % FRAMES(TM_REWARD_INCREMENT_INTERVAL) == 0)
+    else if (
+        timer > interest_start_time + TM_REWARD_DISPLAY_INTERVAL &&
+        timer % FRAMES(TM_REWARD_INCREMENT_INTERVAL) == 0
+    )
     {
         interest_to_count--;
         tte_printf(
@@ -3887,8 +3889,9 @@ static void game_round_end_display_rewards()
     {
         game_round_end_print_hand_reward(hand_y_offset);
     }
-    else if (interest_start_time != UNDEFINED && timer >= interest_start_time &&
-             interest_to_count > 0)
+    else if (
+        interest_start_time != UNDEFINED && timer >= interest_start_time && interest_to_count > 0
+    )
     {
         game_round_end_print_interest_reward(interest_y_offset);
     }

--- a/source/game.c
+++ b/source/game.c
@@ -1978,11 +1978,10 @@ static void game_round_on_init(GameVariables* vars)
     // Apply boss blind round-start modifications (hand / discard counts).
     // These run after game_round_end_cashout() has already reset hands and
     // discards to their maximums, so overwriting them here is intentional.
-    if (current_blind == BLIND_TYPE_BOSS)
+    if (current_blind > BLIND_TYPE_BIG)
     {
-        enum BossBlindId boss_id = boss_blind_get_for_ante(ante);
         boss_blind_reset();
-        boss_blind_apply_round_start(boss_id, &hands, &discards, &hand_size);
+        boss_blind_apply_round_start(current_blind, &hands, &discards, &hand_size);
         display_hands(hands);
         display_discards(discards);
     }
@@ -2306,8 +2305,8 @@ static bool can_play_hand(void)
         return false;
 
     // Boss blind play restrictions (The Psychic: exactly 5 cards; The Eye: no repeated hand types)
-    if (current_blind == BLIND_TYPE_BOSS &&
-        !boss_blind_validate_play(boss_blind_get_for_ante(ante), hand_selections, (int)hand_type))
+    if (current_blind > BLIND_TYPE_BIG &&
+        !boss_blind_validate_play(current_blind, hand_selections, (int)hand_type))
         return false;
 
     return true;
@@ -2742,16 +2741,15 @@ static bool play_ended_played_cards_update(int played_idx)
                 // ── Boss blind post-hand effects ──────────────────────────
                 // These run before played_top is reset so we still know the
                 // number of cards that were played this hand.
-                if (current_blind == BLIND_TYPE_BOSS)
+                if (current_blind > BLIND_TYPE_BIG)
                 {
-                    enum BossBlindId boss_id = boss_blind_get_for_ante(ante);
                     int n_played = played_top + 1;
 
                     // The Eye: record the hand type so it cannot be played again.
-                    boss_blind_register_hand(boss_id, (int)hand_type);
+                    boss_blind_register_hand(current_blind, (int)hand_type);
 
                     // The Tooth: lose $1 per card played.
-                    int penalty = boss_blind_get_tooth_penalty(boss_id, n_played);
+                    int penalty = boss_blind_get_tooth_penalty(current_blind, n_played);
                     if (penalty > 0)
                     {
                         money = (money > penalty) ? money - penalty : 0;
@@ -2759,7 +2757,7 @@ static bool play_ended_played_cards_update(int played_idx)
                     }
 
                     // The Ox: playing any hand drains money to $0.
-                    if (boss_blind_is_ox_active(boss_id))
+                    if (boss_blind_is_ox_active(current_blind))
                     {
                         money = 0;
                         display_money();
@@ -2768,7 +2766,7 @@ static bool play_ended_played_cards_update(int played_idx)
                     // The Hook: discard the 2 topmost held cards.
                     // TODO: Animate the removal using the HAND_DISCARD state
                     //       and randomise which cards are chosen.
-                    int hook_count = boss_blind_get_hook_count(boss_id);
+                    int hook_count = boss_blind_get_hook_count(current_blind);
                     for (int bh = 0; bh < hook_count; bh++)
                     {
                         // Skip any NULL slots left by previously played cards.

--- a/tests/boss_blind_effects/Makefile
+++ b/tests/boss_blind_effects/Makefile
@@ -1,0 +1,15 @@
+CC     := gcc
+CFLAGS := -I../../include -I. \
+          -g -O3 -std=gnu23 -Wall -Werror
+
+SRC := boss_blind_effects_test.c ../../source/boss_blind_effects.c
+OUT := build/boss_blind_effects_test
+
+$(OUT): $(SRC) | build
+	$(CC) $(CFLAGS) -o $@ $^
+
+build:
+	mkdir -p build
+
+clean:
+	rm -f $(OUT)

--- a/tests/boss_blind_effects/Makefile
+++ b/tests/boss_blind_effects/Makefile
@@ -1,6 +1,6 @@
 CC     := gcc
-CFLAGS := -I../../include -I. \
-          -g -O3 -std=gnu23 -Wall -Werror
+# -I. before -I../../include so the local blind.h stub shadows the real one.
+CFLAGS := -I. -I../../include           -g -O3 -std=gnu23 -Wall -Werror
 
 SRC := boss_blind_effects_test.c ../../source/boss_blind_effects.c
 OUT := build/boss_blind_effects_test

--- a/tests/boss_blind_effects/blind.h
+++ b/tests/boss_blind_effects/blind.h
@@ -1,0 +1,50 @@
+/**
+ * Test stub for blind.h.
+ * Provides BlindType enum (matching #352) without GBA-specific headers.
+ */
+#ifndef BLIND_H
+#define BLIND_H
+
+// clang-format off
+enum BlindType
+{
+    BLIND_TYPE_SMALL,
+    BLIND_TYPE_BIG,
+
+    BLIND_TYPE_BOSS,
+    BLIND_TYPE_HOOK = BLIND_TYPE_BOSS,
+    BLIND_TYPE_OX,
+    BLIND_TYPE_HOUSE,
+    BLIND_TYPE_WALL,
+    BLIND_TYPE_WHEEL,
+    BLIND_TYPE_ARM,
+    BLIND_TYPE_CLUB,
+    BLIND_TYPE_FISH,
+    BLIND_TYPE_PSYCHIC,
+    BLIND_TYPE_GOAD,
+    BLIND_TYPE_WATER,
+    BLIND_TYPE_WINDOW,
+    BLIND_TYPE_MANACLE,
+    BLIND_TYPE_EYE,
+    BLIND_TYPE_MOUTH,
+    BLIND_TYPE_PLANT,
+    BLIND_TYPE_SERPENT,
+    BLIND_TYPE_PILLAR,
+    BLIND_TYPE_NEEDLE,
+    BLIND_TYPE_HEAD,
+    BLIND_TYPE_TOOTH,
+    BLIND_TYPE_FLINT,
+    BLIND_TYPE_MARK,
+
+    BLIND_TYPE_SHOWDOWN,
+    BLIND_TYPE_ACORN = BLIND_TYPE_SHOWDOWN,
+    BLIND_TYPE_LEAF,
+    BLIND_TYPE_VESSEL,
+    BLIND_TYPE_HEART,
+    BLIND_TYPE_BELL,
+
+    BLIND_TYPE_MAX
+};
+// clang-format on
+
+#endif // BLIND_H

--- a/tests/boss_blind_effects/boss_blind_effects_test.c
+++ b/tests/boss_blind_effects/boss_blind_effects_test.c
@@ -1,0 +1,191 @@
+#include "boss_blind_effects.h"
+#include <assert.h>
+#include <stdio.h>
+
+/* ── Helpers ──────────────────────────────────────────────────────────────── */
+
+/* Hand type constants mirrored from game.h (kept local to avoid GBA deps). */
+#define HT_NONE          0
+#define HT_HIGH_CARD     1
+#define HT_PAIR          2
+#define HT_TWO_PAIR      3
+#define HT_THREE_OAK     4
+#define HT_STRAIGHT      5
+#define HT_FLUSH         6
+
+/* ── boss_blind_get_for_ante ──────────────────────────────────────────────── */
+
+static void test_get_for_ante(void)
+{
+    /* Ante 1 → The Needle (index 0) */
+    assert(boss_blind_get_for_ante(1) == BOSS_THE_NEEDLE);
+    /* Ante 2 → The Water  (index 1) */
+    assert(boss_blind_get_for_ante(2) == BOSS_THE_WATER);
+    /* Ante 7 → The Ox     (index 6) */
+    assert(boss_blind_get_for_ante(7) == BOSS_THE_OX);
+    /* Ante 8 cycles back to The Needle */
+    assert(boss_blind_get_for_ante(8) == BOSS_THE_NEEDLE);
+    /* Ante 0 (clamped to 1) → The Needle */
+    assert(boss_blind_get_for_ante(0) == BOSS_THE_NEEDLE);
+
+    printf("test_get_for_ante: PASS\n");
+}
+
+/* ── boss_blind_apply_round_start ─────────────────────────────────────────── */
+
+static void test_apply_round_start_needle(void)
+{
+    int hands = 4, discards = 4, hand_size = 8;
+    boss_blind_apply_round_start(BOSS_THE_NEEDLE, &hands, &discards, &hand_size);
+    assert(hands     == 1);  /* The Needle caps hands to 1 */
+    assert(discards  == 4);  /* Discards untouched          */
+    assert(hand_size == 8);  /* Hand size untouched          */
+    printf("test_apply_round_start_needle: PASS\n");
+}
+
+static void test_apply_round_start_water(void)
+{
+    int hands = 4, discards = 4, hand_size = 8;
+    boss_blind_apply_round_start(BOSS_THE_WATER, &hands, &discards, &hand_size);
+    assert(hands     == 4);  /* Hands untouched              */
+    assert(discards  == 0);  /* The Water removes discards   */
+    assert(hand_size == 8);  /* Hand size untouched          */
+    printf("test_apply_round_start_water: PASS\n");
+}
+
+static void test_apply_round_start_no_effect(void)
+{
+    int hands = 4, discards = 4, hand_size = 8;
+    /* Blinds with no round-start stat change should leave everything alone. */
+    boss_blind_apply_round_start(BOSS_THE_HOOK,    &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_PSYCHIC, &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_TOOTH,   &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_EYE,     &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_OX,      &hands, &discards, &hand_size);
+    assert(hands == 4 && discards == 4 && hand_size == 8);
+    printf("test_apply_round_start_no_effect: PASS\n");
+}
+
+/* ── boss_blind_validate_play ─────────────────────────────────────────────── */
+
+static void test_validate_play_psychic(void)
+{
+    /* The Psychic: must play exactly 5 cards. */
+    assert(!boss_blind_validate_play(BOSS_THE_PSYCHIC, 4, HT_STRAIGHT));
+    assert( boss_blind_validate_play(BOSS_THE_PSYCHIC, 5, HT_STRAIGHT));
+    assert(!boss_blind_validate_play(BOSS_THE_PSYCHIC, 6, HT_FLUSH));
+    printf("test_validate_play_psychic: PASS\n");
+}
+
+static void test_validate_play_eye(void)
+{
+    boss_blind_reset();
+
+    /* First time playing HIGH_CARD – allowed. */
+    assert(boss_blind_validate_play(BOSS_THE_EYE, 1, HT_HIGH_CARD));
+    boss_blind_register_hand(BOSS_THE_EYE, HT_HIGH_CARD);
+
+    /* Second time playing HIGH_CARD – rejected. */
+    assert(!boss_blind_validate_play(BOSS_THE_EYE, 1, HT_HIGH_CARD));
+
+    /* Different type (PAIR) – still allowed. */
+    assert(boss_blind_validate_play(BOSS_THE_EYE, 2, HT_PAIR));
+
+    /* After reset, HIGH_CARD is allowed again. */
+    boss_blind_reset();
+    assert(boss_blind_validate_play(BOSS_THE_EYE, 1, HT_HIGH_CARD));
+
+    printf("test_validate_play_eye: PASS\n");
+}
+
+static void test_validate_play_others_always_true(void)
+{
+    /* Blinds other than The Psychic and The Eye never block play. */
+    assert(boss_blind_validate_play(BOSS_THE_NEEDLE,  3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_WATER,   3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_HOOK,    3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_TOOTH,   3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_OX,      3, HT_FLUSH));
+    printf("test_validate_play_others_always_true: PASS\n");
+}
+
+/* ── boss_blind_get_hook_count ─────────────────────────────────────────────── */
+
+static void test_hook_count(void)
+{
+    assert(boss_blind_get_hook_count(BOSS_THE_HOOK)    == 2);
+    assert(boss_blind_get_hook_count(BOSS_THE_NEEDLE)  == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_WATER)   == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_PSYCHIC) == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_TOOTH)   == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_EYE)     == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_OX)      == 0);
+    printf("test_hook_count: PASS\n");
+}
+
+/* ── boss_blind_get_tooth_penalty ─────────────────────────────────────────── */
+
+static void test_tooth_penalty(void)
+{
+    /* The Tooth: $1 per card played. */
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 1) == 1);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 5) == 5);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 0) == 0);
+
+    /* All other blinds: no penalty. */
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_NEEDLE,  3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_WATER,   3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_HOOK,    3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_PSYCHIC, 3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_EYE,     3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_OX,      3) == 0);
+
+    printf("test_tooth_penalty: PASS\n");
+}
+
+/* ── boss_blind_is_ox_active ──────────────────────────────────────────────── */
+
+static void test_ox_active(void)
+{
+    assert( boss_blind_is_ox_active(BOSS_THE_OX));
+    assert(!boss_blind_is_ox_active(BOSS_THE_NEEDLE));
+    assert(!boss_blind_is_ox_active(BOSS_THE_WATER));
+    assert(!boss_blind_is_ox_active(BOSS_THE_HOOK));
+    assert(!boss_blind_is_ox_active(BOSS_THE_PSYCHIC));
+    assert(!boss_blind_is_ox_active(BOSS_THE_TOOTH));
+    assert(!boss_blind_is_ox_active(BOSS_THE_EYE));
+    printf("test_ox_active: PASS\n");
+}
+
+/* ── boss_blind_get_name ──────────────────────────────────────────────────── */
+
+static void test_get_name(void)
+{
+    /* Spot-check a few names (exact strings must match boss_blind_effects.c). */
+    assert(boss_blind_get_name(BOSS_THE_NEEDLE)  != 0);
+    assert(boss_blind_get_name(BOSS_THE_OX)      != 0);
+    /* Out-of-range ID must not crash and must return a non-NULL string. */
+    assert(boss_blind_get_name((enum BossBlindId)-1) != 0);
+    assert(boss_blind_get_name(BOSS_BLIND_ID_MAX)    != 0);
+    printf("test_get_name: PASS\n");
+}
+
+/* ── main ─────────────────────────────────────────────────────────────────── */
+
+int main(void)
+{
+    test_get_for_ante();
+    test_apply_round_start_needle();
+    test_apply_round_start_water();
+    test_apply_round_start_no_effect();
+    test_validate_play_psychic();
+    test_validate_play_eye();
+    test_validate_play_others_always_true();
+    test_hook_count();
+    test_tooth_penalty();
+    test_ox_active();
+    test_get_name();
+
+    printf("\nAll boss_blind_effects tests passed.\n");
+    return 0;
+}

--- a/tests/boss_blind_effects/boss_blind_effects_test.c
+++ b/tests/boss_blind_effects/boss_blind_effects_test.c
@@ -1,11 +1,8 @@
-#include "boss_blind_effects.h"
+#include boss_blind_effects.h
 
 #include <assert.h>
 #include <stdio.h>
 
-/* ── Helpers ──────────────────────────────────────────────────────────────── */
-
-/* Hand type constants mirrored from game.h (kept local to avoid GBA deps). */
 #define HT_NONE      0
 #define HT_HIGH_CARD 1
 #define HT_PAIR      2
@@ -14,168 +11,104 @@
 #define HT_STRAIGHT  5
 #define HT_FLUSH     6
 
-/* ── boss_blind_get_for_ante ──────────────────────────────────────────────── */
-
-static void test_get_for_ante(void)
-{
-    /* Ante 1 → The Needle (index 0) */
-    assert(boss_blind_get_for_ante(1) == BOSS_THE_NEEDLE);
-    /* Ante 2 → The Water  (index 1) */
-    assert(boss_blind_get_for_ante(2) == BOSS_THE_WATER);
-    /* Ante 7 → The Ox     (index 6) */
-    assert(boss_blind_get_for_ante(7) == BOSS_THE_OX);
-    /* Ante 8 cycles back to The Needle */
-    assert(boss_blind_get_for_ante(8) == BOSS_THE_NEEDLE);
-    /* Ante 0 (clamped to 1) → The Needle */
-    assert(boss_blind_get_for_ante(0) == BOSS_THE_NEEDLE);
-
-    printf("test_get_for_ante: PASS\n");
-}
-
-/* ── boss_blind_apply_round_start ─────────────────────────────────────────── */
-
 static void test_apply_round_start_needle(void)
 {
     int hands = 4, discards = 4, hand_size = 8;
-    boss_blind_apply_round_start(BOSS_THE_NEEDLE, &hands, &discards, &hand_size);
-    assert(hands == 1);     /* The Needle caps hands to 1 */
-    assert(discards == 4);  /* Discards untouched          */
-    assert(hand_size == 8); /* Hand size untouched          */
-    printf("test_apply_round_start_needle: PASS\n");
+    boss_blind_apply_round_start(BLIND_TYPE_NEEDLE, &hands, &discards, &hand_size);
+    assert(hands == 1 && discards == 4 && hand_size == 8);
+    printf(test_apply_round_start_needle: PASS\n);
 }
 
 static void test_apply_round_start_water(void)
 {
     int hands = 4, discards = 4, hand_size = 8;
-    boss_blind_apply_round_start(BOSS_THE_WATER, &hands, &discards, &hand_size);
-    assert(hands == 4);     /* Hands untouched              */
-    assert(discards == 0);  /* The Water removes discards   */
-    assert(hand_size == 8); /* Hand size untouched          */
-    printf("test_apply_round_start_water: PASS\n");
+    boss_blind_apply_round_start(BLIND_TYPE_WATER, &hands, &discards, &hand_size);
+    assert(hands == 4 && discards == 0 && hand_size == 8);
+    printf(test_apply_round_start_water: PASS\n);
 }
 
 static void test_apply_round_start_no_effect(void)
 {
     int hands = 4, discards = 4, hand_size = 8;
-    /* Blinds with no round-start stat change should leave everything alone. */
-    boss_blind_apply_round_start(BOSS_THE_HOOK, &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_PSYCHIC, &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_TOOTH, &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_EYE, &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_OX, &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BLIND_TYPE_HOOK,    &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BLIND_TYPE_PSYCHIC, &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BLIND_TYPE_TOOTH,   &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BLIND_TYPE_EYE,     &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BLIND_TYPE_OX,      &hands, &discards, &hand_size);
     assert(hands == 4 && discards == 4 && hand_size == 8);
-    printf("test_apply_round_start_no_effect: PASS\n");
+    printf(test_apply_round_start_no_effect: PASS\n);
 }
-
-/* ── boss_blind_validate_play ─────────────────────────────────────────────── */
 
 static void test_validate_play_psychic(void)
 {
-    /* The Psychic: must play exactly 5 cards. */
-    assert(!boss_blind_validate_play(BOSS_THE_PSYCHIC, 4, HT_STRAIGHT));
-    assert(boss_blind_validate_play(BOSS_THE_PSYCHIC, 5, HT_STRAIGHT));
-    assert(!boss_blind_validate_play(BOSS_THE_PSYCHIC, 6, HT_FLUSH));
-    printf("test_validate_play_psychic: PASS\n");
+    assert(!boss_blind_validate_play(BLIND_TYPE_PSYCHIC, 4, HT_STRAIGHT));
+    assert( boss_blind_validate_play(BLIND_TYPE_PSYCHIC, 5, HT_STRAIGHT));
+    assert(!boss_blind_validate_play(BLIND_TYPE_PSYCHIC, 6, HT_FLUSH));
+    printf(test_validate_play_psychic: PASS\n);
 }
 
 static void test_validate_play_eye(void)
 {
     boss_blind_reset();
-
-    /* First time playing HIGH_CARD – allowed. */
-    assert(boss_blind_validate_play(BOSS_THE_EYE, 1, HT_HIGH_CARD));
-    boss_blind_register_hand(BOSS_THE_EYE, HT_HIGH_CARD);
-
-    /* Second time playing HIGH_CARD – rejected. */
-    assert(!boss_blind_validate_play(BOSS_THE_EYE, 1, HT_HIGH_CARD));
-
-    /* Different type (PAIR) – still allowed. */
-    assert(boss_blind_validate_play(BOSS_THE_EYE, 2, HT_PAIR));
-
-    /* After reset, HIGH_CARD is allowed again. */
+    assert( boss_blind_validate_play(BLIND_TYPE_EYE, 1, HT_HIGH_CARD));
+    boss_blind_register_hand(BLIND_TYPE_EYE, HT_HIGH_CARD);
+    assert(!boss_blind_validate_play(BLIND_TYPE_EYE, 1, HT_HIGH_CARD));
+    assert( boss_blind_validate_play(BLIND_TYPE_EYE, 2, HT_PAIR));
     boss_blind_reset();
-    assert(boss_blind_validate_play(BOSS_THE_EYE, 1, HT_HIGH_CARD));
-
-    printf("test_validate_play_eye: PASS\n");
+    assert( boss_blind_validate_play(BLIND_TYPE_EYE, 1, HT_HIGH_CARD));
+    printf(test_validate_play_eye: PASS\n);
 }
 
 static void test_validate_play_others_always_true(void)
 {
-    /* Blinds other than The Psychic and The Eye never block play. */
-    assert(boss_blind_validate_play(BOSS_THE_NEEDLE, 3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_WATER, 3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_HOOK, 3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_TOOTH, 3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_OX, 3, HT_FLUSH));
-    printf("test_validate_play_others_always_true: PASS\n");
+    assert(boss_blind_validate_play(BLIND_TYPE_NEEDLE, 3, HT_FLUSH));
+    assert(boss_blind_validate_play(BLIND_TYPE_WATER,  3, HT_FLUSH));
+    assert(boss_blind_validate_play(BLIND_TYPE_HOOK,   3, HT_FLUSH));
+    assert(boss_blind_validate_play(BLIND_TYPE_TOOTH,  3, HT_FLUSH));
+    assert(boss_blind_validate_play(BLIND_TYPE_OX,     3, HT_FLUSH));
+    printf(test_validate_play_others_always_true: PASS\n);
 }
-
-/* ── boss_blind_get_hook_count ─────────────────────────────────────────────── */
 
 static void test_hook_count(void)
 {
-    assert(boss_blind_get_hook_count(BOSS_THE_HOOK) == 2);
-    assert(boss_blind_get_hook_count(BOSS_THE_NEEDLE) == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_WATER) == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_PSYCHIC) == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_TOOTH) == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_EYE) == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_OX) == 0);
-    printf("test_hook_count: PASS\n");
+    assert(boss_blind_get_hook_count(BLIND_TYPE_HOOK)    == 2);
+    assert(boss_blind_get_hook_count(BLIND_TYPE_NEEDLE)  == 0);
+    assert(boss_blind_get_hook_count(BLIND_TYPE_WATER)   == 0);
+    assert(boss_blind_get_hook_count(BLIND_TYPE_PSYCHIC) == 0);
+    assert(boss_blind_get_hook_count(BLIND_TYPE_TOOTH)   == 0);
+    assert(boss_blind_get_hook_count(BLIND_TYPE_EYE)     == 0);
+    assert(boss_blind_get_hook_count(BLIND_TYPE_OX)      == 0);
+    printf(test_hook_count: PASS\n);
 }
-
-/* ── boss_blind_get_tooth_penalty ─────────────────────────────────────────── */
 
 static void test_tooth_penalty(void)
 {
-    /* The Tooth: $1 per card played. */
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 1) == 1);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 5) == 5);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 0) == 0);
-
-    /* All other blinds: no penalty. */
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_NEEDLE, 3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_WATER, 3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_HOOK, 3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_PSYCHIC, 3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_EYE, 3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_OX, 3) == 0);
-
-    printf("test_tooth_penalty: PASS\n");
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_TOOTH,   1) == 1);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_TOOTH,   5) == 5);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_TOOTH,   0) == 0);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_NEEDLE,  3) == 0);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_WATER,   3) == 0);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_HOOK,    3) == 0);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_PSYCHIC, 3) == 0);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_EYE,     3) == 0);
+    assert(boss_blind_get_tooth_penalty(BLIND_TYPE_OX,      3) == 0);
+    printf(test_tooth_penalty: PASS\n);
 }
-
-/* ── boss_blind_is_ox_active ──────────────────────────────────────────────── */
 
 static void test_ox_active(void)
 {
-    assert(boss_blind_is_ox_active(BOSS_THE_OX));
-    assert(!boss_blind_is_ox_active(BOSS_THE_NEEDLE));
-    assert(!boss_blind_is_ox_active(BOSS_THE_WATER));
-    assert(!boss_blind_is_ox_active(BOSS_THE_HOOK));
-    assert(!boss_blind_is_ox_active(BOSS_THE_PSYCHIC));
-    assert(!boss_blind_is_ox_active(BOSS_THE_TOOTH));
-    assert(!boss_blind_is_ox_active(BOSS_THE_EYE));
-    printf("test_ox_active: PASS\n");
+    assert( boss_blind_is_ox_active(BLIND_TYPE_OX));
+    assert(!boss_blind_is_ox_active(BLIND_TYPE_NEEDLE));
+    assert(!boss_blind_is_ox_active(BLIND_TYPE_WATER));
+    assert(!boss_blind_is_ox_active(BLIND_TYPE_HOOK));
+    assert(!boss_blind_is_ox_active(BLIND_TYPE_PSYCHIC));
+    assert(!boss_blind_is_ox_active(BLIND_TYPE_TOOTH));
+    assert(!boss_blind_is_ox_active(BLIND_TYPE_EYE));
+    printf(test_ox_active: PASS\n);
 }
-
-/* ── boss_blind_get_name ──────────────────────────────────────────────────── */
-
-static void test_get_name(void)
-{
-    /* Spot-check a few names (exact strings must match boss_blind_effects.c). */
-    assert(boss_blind_get_name(BOSS_THE_NEEDLE) != 0);
-    assert(boss_blind_get_name(BOSS_THE_OX) != 0);
-    /* Out-of-range ID must not crash and must return a non-NULL string. */
-    assert(boss_blind_get_name((enum BossBlindId) - 1) != 0);
-    assert(boss_blind_get_name(BOSS_BLIND_ID_MAX) != 0);
-    printf("test_get_name: PASS\n");
-}
-
-/* ── main ─────────────────────────────────────────────────────────────────── */
 
 int main(void)
 {
-    test_get_for_ante();
     test_apply_round_start_needle();
     test_apply_round_start_water();
     test_apply_round_start_no_effect();
@@ -185,8 +118,7 @@ int main(void)
     test_hook_count();
     test_tooth_penalty();
     test_ox_active();
-    test_get_name();
 
-    printf("\nAll boss_blind_effects tests passed.\n");
+    printf(\nAll boss_blind_effects tests passed.\n);
     return 0;
 }

--- a/tests/boss_blind_effects/boss_blind_effects_test.c
+++ b/tests/boss_blind_effects/boss_blind_effects_test.c
@@ -1,17 +1,18 @@
 #include "boss_blind_effects.h"
+
 #include <assert.h>
 #include <stdio.h>
 
 /* ── Helpers ──────────────────────────────────────────────────────────────── */
 
 /* Hand type constants mirrored from game.h (kept local to avoid GBA deps). */
-#define HT_NONE          0
-#define HT_HIGH_CARD     1
-#define HT_PAIR          2
-#define HT_TWO_PAIR      3
-#define HT_THREE_OAK     4
-#define HT_STRAIGHT      5
-#define HT_FLUSH         6
+#define HT_NONE      0
+#define HT_HIGH_CARD 1
+#define HT_PAIR      2
+#define HT_TWO_PAIR  3
+#define HT_THREE_OAK 4
+#define HT_STRAIGHT  5
+#define HT_FLUSH     6
 
 /* ── boss_blind_get_for_ante ──────────────────────────────────────────────── */
 
@@ -37,9 +38,9 @@ static void test_apply_round_start_needle(void)
 {
     int hands = 4, discards = 4, hand_size = 8;
     boss_blind_apply_round_start(BOSS_THE_NEEDLE, &hands, &discards, &hand_size);
-    assert(hands     == 1);  /* The Needle caps hands to 1 */
-    assert(discards  == 4);  /* Discards untouched          */
-    assert(hand_size == 8);  /* Hand size untouched          */
+    assert(hands == 1);     /* The Needle caps hands to 1 */
+    assert(discards == 4);  /* Discards untouched          */
+    assert(hand_size == 8); /* Hand size untouched          */
     printf("test_apply_round_start_needle: PASS\n");
 }
 
@@ -47,9 +48,9 @@ static void test_apply_round_start_water(void)
 {
     int hands = 4, discards = 4, hand_size = 8;
     boss_blind_apply_round_start(BOSS_THE_WATER, &hands, &discards, &hand_size);
-    assert(hands     == 4);  /* Hands untouched              */
-    assert(discards  == 0);  /* The Water removes discards   */
-    assert(hand_size == 8);  /* Hand size untouched          */
+    assert(hands == 4);     /* Hands untouched              */
+    assert(discards == 0);  /* The Water removes discards   */
+    assert(hand_size == 8); /* Hand size untouched          */
     printf("test_apply_round_start_water: PASS\n");
 }
 
@@ -57,11 +58,11 @@ static void test_apply_round_start_no_effect(void)
 {
     int hands = 4, discards = 4, hand_size = 8;
     /* Blinds with no round-start stat change should leave everything alone. */
-    boss_blind_apply_round_start(BOSS_THE_HOOK,    &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_HOOK, &hands, &discards, &hand_size);
     boss_blind_apply_round_start(BOSS_THE_PSYCHIC, &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_TOOTH,   &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_EYE,     &hands, &discards, &hand_size);
-    boss_blind_apply_round_start(BOSS_THE_OX,      &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_TOOTH, &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_EYE, &hands, &discards, &hand_size);
+    boss_blind_apply_round_start(BOSS_THE_OX, &hands, &discards, &hand_size);
     assert(hands == 4 && discards == 4 && hand_size == 8);
     printf("test_apply_round_start_no_effect: PASS\n");
 }
@@ -72,7 +73,7 @@ static void test_validate_play_psychic(void)
 {
     /* The Psychic: must play exactly 5 cards. */
     assert(!boss_blind_validate_play(BOSS_THE_PSYCHIC, 4, HT_STRAIGHT));
-    assert( boss_blind_validate_play(BOSS_THE_PSYCHIC, 5, HT_STRAIGHT));
+    assert(boss_blind_validate_play(BOSS_THE_PSYCHIC, 5, HT_STRAIGHT));
     assert(!boss_blind_validate_play(BOSS_THE_PSYCHIC, 6, HT_FLUSH));
     printf("test_validate_play_psychic: PASS\n");
 }
@@ -101,11 +102,11 @@ static void test_validate_play_eye(void)
 static void test_validate_play_others_always_true(void)
 {
     /* Blinds other than The Psychic and The Eye never block play. */
-    assert(boss_blind_validate_play(BOSS_THE_NEEDLE,  3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_WATER,   3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_HOOK,    3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_TOOTH,   3, HT_FLUSH));
-    assert(boss_blind_validate_play(BOSS_THE_OX,      3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_NEEDLE, 3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_WATER, 3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_HOOK, 3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_TOOTH, 3, HT_FLUSH));
+    assert(boss_blind_validate_play(BOSS_THE_OX, 3, HT_FLUSH));
     printf("test_validate_play_others_always_true: PASS\n");
 }
 
@@ -113,13 +114,13 @@ static void test_validate_play_others_always_true(void)
 
 static void test_hook_count(void)
 {
-    assert(boss_blind_get_hook_count(BOSS_THE_HOOK)    == 2);
-    assert(boss_blind_get_hook_count(BOSS_THE_NEEDLE)  == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_WATER)   == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_HOOK) == 2);
+    assert(boss_blind_get_hook_count(BOSS_THE_NEEDLE) == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_WATER) == 0);
     assert(boss_blind_get_hook_count(BOSS_THE_PSYCHIC) == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_TOOTH)   == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_EYE)     == 0);
-    assert(boss_blind_get_hook_count(BOSS_THE_OX)      == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_TOOTH) == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_EYE) == 0);
+    assert(boss_blind_get_hook_count(BOSS_THE_OX) == 0);
     printf("test_hook_count: PASS\n");
 }
 
@@ -133,12 +134,12 @@ static void test_tooth_penalty(void)
     assert(boss_blind_get_tooth_penalty(BOSS_THE_TOOTH, 0) == 0);
 
     /* All other blinds: no penalty. */
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_NEEDLE,  3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_WATER,   3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_HOOK,    3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_NEEDLE, 3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_WATER, 3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_HOOK, 3) == 0);
     assert(boss_blind_get_tooth_penalty(BOSS_THE_PSYCHIC, 3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_EYE,     3) == 0);
-    assert(boss_blind_get_tooth_penalty(BOSS_THE_OX,      3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_EYE, 3) == 0);
+    assert(boss_blind_get_tooth_penalty(BOSS_THE_OX, 3) == 0);
 
     printf("test_tooth_penalty: PASS\n");
 }
@@ -147,7 +148,7 @@ static void test_tooth_penalty(void)
 
 static void test_ox_active(void)
 {
-    assert( boss_blind_is_ox_active(BOSS_THE_OX));
+    assert(boss_blind_is_ox_active(BOSS_THE_OX));
     assert(!boss_blind_is_ox_active(BOSS_THE_NEEDLE));
     assert(!boss_blind_is_ox_active(BOSS_THE_WATER));
     assert(!boss_blind_is_ox_active(BOSS_THE_HOOK));
@@ -162,11 +163,11 @@ static void test_ox_active(void)
 static void test_get_name(void)
 {
     /* Spot-check a few names (exact strings must match boss_blind_effects.c). */
-    assert(boss_blind_get_name(BOSS_THE_NEEDLE)  != 0);
-    assert(boss_blind_get_name(BOSS_THE_OX)      != 0);
+    assert(boss_blind_get_name(BOSS_THE_NEEDLE) != 0);
+    assert(boss_blind_get_name(BOSS_THE_OX) != 0);
     /* Out-of-range ID must not crash and must return a non-NULL string. */
-    assert(boss_blind_get_name((enum BossBlindId)-1) != 0);
-    assert(boss_blind_get_name(BOSS_BLIND_ID_MAX)    != 0);
+    assert(boss_blind_get_name((enum BossBlindId) - 1) != 0);
+    assert(boss_blind_get_name(BOSS_BLIND_ID_MAX) != 0);
     printf("test_get_name: PASS\n");
 }
 


### PR DESCRIPTION
## Summary

Implements 7 boss blind effects as a new self-contained module (), hooking into  at three call-sites. Partially addresses #354.

### Boss blinds

| Blind | Effect |
|-------|--------|
| **The Needle** | Only 1 hand allowed per round |
| **The Water** | Start with 0 discards |
| **The Hook** | After scoring, 2 held cards are discarded |
| **The Psychic** | Must play exactly 5 cards |
| **The Tooth** | Lose $1 for each card played |
| **The Eye** | Each hand type can only be played once per round |
| **The Ox** | Playing any hand drains money to $0 |

### Changes to 

- **** — calls  after cashout has reset counters; refreshes HUD.
- **** — calls  to gray-out the Play button for The Psychic (must select 5) and The Eye (no repeated hand types).
- **** — after the last played card exits the screen, applies The Eye registration, The Tooth penalty, The Ox drain, and The Hook discard.

### Tests

 — standalone host-side suite (gcc, no GBA deps) covering every public API function. A local `blind.h` stub in the test directory provides the `BlindType` enum without pulling in GBA-specific headers; the Makefile include order ensures it shadows the real header during test compilation.

### Depends on

This PR is ready to be rebased on top of #352. The `BossBlindId` enum has been removed in favour of the `BlindType` enum from #352, and all call-sites in `game.c` now use `current_blind` directly (checking `current_blind > BLIND_TYPE_BIG` rather than `== BLIND_TYPE_BOSS`).

### Known limitations / TODOs

- **The Hook** currently removes the *topmost* 2 held cards; proper randomisation + HAND_DISCARD animation is a follow-up.
- **The Manacle** (hand size −1) needs a  variable to be undone each round — excluded from this PR.