### PR TITLE
Updated Makefile to hardcode the name of the output rom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LIBTONC := $(DEVKITPRO)/libtonc
 # the makefile is found
 #
 #---------------------------------------------------------------------------------
-TARGET         := $(notdir $(CURDIR))
+TARGET         := balatro-gba
 BUILD          := build
 SOURCES	       := source source/game
 INCLUDES       := include include/game


### PR DESCRIPTION
Fixed issue #421:

Currently, our Makefile names the ROM based on the directory of the repo (the directory the Makefile is in). This means that if someone checks out the repo and renames the directory, then instructions and scripts that specifically reference balatro-gba.gba are no longer correct.

The Makefile needs to be updated to always name the ROM: balatro-gba.gba