### PR TITLE
Fixed blind sprite flip issue by removing affine attribute

### DIFF
--- a/source/blind.c
+++ b/source/blind.c
@@ -231,7 +231,7 @@ Sprite* blind_token_new(enum BlindType type, int x, int y, int layer)
     apply_blind_tiles(type, layer);
 
     Sprite* sprite = sprite_new(
-        ATTR0_SQUARE | ATTR0_4BPP | ATTR0_AFF,
+        ATTR0_SQUARE | ATTR0_4BPP,
         ATTR1_SIZE_32x32,
         get_layer_tile_index(layer),
         get_blind_pb(type),


### PR DESCRIPTION
fixes #438
So it seems I found the issue. The actual write that changed the value was in `sprite_new()` in this line.
```
if (a0 & ATTR0_AFF)
{
   ...
    obj_aff_identity(&obj_aff_buffer[aff_index]);
}
```

When an affine sprite is created it's transform is set to the identity. Since the affine sprite memory is interleaved with the regular sprite memory, this overwrote the the flip bit, I suppose this was only sometimes done because it was affected by the number of affine joker and card sprites.
This code was reached because the blind sprite was set to be affine, and I don't see a reason why it should be and @MathisMartin31 it doesn't seem like you intended it (https://github.com/GBALATRO/balatro-gba/pull/352/changes/379063915f83caf494bdd689ed0bbc0aeb94d5ab) so the fix was just to remove the affine attribute.