### PR TITLE
[Example] Direct write to OAM rather than using intermediate buffer

### DIFF
--- a/source/sprite.c
+++ b/source/sprite.c
@@ -11,8 +11,8 @@
 #include <tonc.h>
 #include <tonc_oam.h>
 
-OBJ_ATTR obj_buffer[MAX_SPRITES];
-OBJ_AFFINE* obj_aff_buffer = (OBJ_AFFINE*)obj_buffer;
+OBJ_ATTR* obj_buffer = obj_mem;
+OBJ_AFFINE* obj_aff_buffer = obj_aff_mem;
 
 static Sprite* free_sprites[MAX_SPRITES] = {NULL};
 static bool free_affines[MAX_AFFINES] = {false};
@@ -142,8 +142,8 @@ void sprite_init()
 
 void sprite_draw()
 {
-    obj_aff_copy(obj_aff_mem, obj_aff_buffer, MAX_AFFINES);
-    oam_copy(oam_mem, obj_buffer, MAX_SPRITES);
+    // obj_aff_copy(obj_aff_mem, obj_aff_buffer, MAX_AFFINES);
+    // oam_copy(oam_mem, obj_buffer, MAX_SPRITES);
 }
 
 int sprite_get_pb(const Sprite* sprite)


### PR DESCRIPTION
For now this is just a quick and dirty demo for #440 as an initial draft of what it would look like with the change.
It has some issues - namely when playing a hand there's a flickering sprite in the top left corner.
<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/1675c2b6-3825-431a-8ae2-20dd2fb405e9" />
<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/f71b4c7a-ee5d-4e5f-a623-f1938a35b80d" />
