### PR TITLE
A few small updates to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
+type: bug
 assignees: 
 
 ---
@@ -22,7 +23,8 @@ Any helpful screenshots or videos
 **What version**
 - **Nightly**: If you downloaded the ROM you can provide either the ROM name, or the name of the zipfile
 - **Mainline Release**: Please provide the name of the release (**Joker Build**, **Itemless Build**, etc)
-- **I Don't Know**: Please try to use the `build_bug_report.py` script in the `scripts/` directory. If there is no output from that, then try to recreate your bug with a new version. 
+- **Built From (Unmodified) Source**: Please specify the branch (e.g. main) and latest commit in your build. If you modified the code, make sure it reproduces in unmodified code before reporting.
+- **I Don't Know**: Upload a zip of the rom you used. Alternatively, please try to use the `build_bug_report.py` script in the `scripts/` directory. If there is no output from that, then try to recreate your bug with a new version.
 
 **What Emulator or Platform were you playing on**
  - e.g. mgba, flashcart


### PR DESCRIPTION
Added instructions for specifying build from source in the bug report template and added issue type bug.
That's usually how I report bugs.
I also added the instruction to just upload a zip of the rom used, so we can run the script and check the version ourselves.