### PR TITLE
docs: clarify clang-format version and usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Please ensure you are using this version to avoid CI formatting failures.
 <summary>Install on Ubuntu / Debian</summary>
 
 ```bash
-sudo apt install clang-format-18
+sudo apt install clang-format
 ```
 
 </details>
@@ -68,13 +68,6 @@ You can check your installed version using:
 ```bash
 clang-format --version
 ```
-
-
-### Verify Installation
-
-You can check your installed version using:
-
-clang-format --version
 
 Ensure the output shows version 18.
 
@@ -104,7 +97,7 @@ clang-format -i include/*.h include/game/*.h source/*.c source/game/*.c
 
 # Or just one
 clang-format -i include/blind.h
-````
+```
 
 #### Disabling Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,9 @@ sudo apt install clang-format
 
 ```bash
 sudo pacman -S clang18
+
+# Add to PATH via 'profile.d'
+echo 'export PATH="/usr/lib/llvm18/bin:${PATH}"' | sudo tee /etc/profile.d/clang-format-18.sh
 ```
 
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,32 @@ Please ensure you are using this version to avoid CI formatting failures.
 
 ### Installation
 
-#### Ubuntu / Debian
-sudo apt install clang-format-18
+<details>
+<summary>Install on Ubuntu / Debian</summary>
 
-#### Arch Linux
-sudo pacman -S clang
+```bash
+sudo apt install clang-format-18
+```
+
+</details>
+
+<details>
+<summary>Install on Arch Linux</summary>
+
+```bash
+sudo pacman -S clang18
+```
+
+</details>
+
+### Verify Installation
+
+You can check your installed version using:
+
+```bash
+clang-format --version
+```
+
 
 ### Verify Installation
 
@@ -76,12 +97,14 @@ If installed locally and you'd prefer to use it in your shell. You can do the fo
 
 ```sh
 # List warnings
-clang-format --dry-run -Werror include/*.h source/*.c
+clang-format --dry-run -Werror include/*.h include/game/*.h source/*.c source/game/*.c
+
 # Modify all files inplace
-clang-format -i include/*.h source/*.c
+clang-format -i include/*.h include/game/*.h source/*.c source/game/*.c
+
 # Or just one
 clang-format -i include/blind.h
-```
+````
 
 #### Disabling Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,29 @@ You can also choose to build the docs yourself [Link in wiki](https://github.com
 
 ### clang-format
 
+### Version
+
+This project currently uses **clang-format version 18**.
+
+Please ensure you are using this version to avoid CI formatting failures.
+
+### Installation
+
+#### Ubuntu / Debian
+sudo apt install clang-format-18
+
+#### Arch Linux
+sudo pacman -S clang
+
+### Verify Installation
+
+You can check your installed version using:
+
+clang-format --version
+
+Ensure the output shows version 18.
+
+
 Running `clang-format` locally is recommended before submitting a PR as it will fail the **CI Checks** if not properly formatted. It is recommended either: 
 1. Run `clang-format` periodically and only commit formatted code. 
 2. Run `clang-format` as a separate commit on larger changes, and review each modified hunk. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ You can also choose to build the docs yourself [Link in wiki](https://github.com
 
 ### clang-format
 
+Running `clang-format` locally is recommended before submitting a PR as it will fail the **CI Checks** if not properly formatted. It is recommended either: 
+1. Run `clang-format` periodically and only commit formatted code. 
+2. Run `clang-format` as a separate commit on larger changes, and review each modified hunk. 
+
+Either way, just ensure you manually review automatic changes.
+
 ### Version
 
 This project currently uses **clang-format version 18**.
@@ -70,13 +76,6 @@ clang-format --version
 ```
 
 Ensure the output shows version 18.
-
-
-Running `clang-format` locally is recommended before submitting a PR as it will fail the **CI Checks** if not properly formatted. It is recommended either: 
-1. Run `clang-format` periodically and only commit formatted code. 
-2. Run `clang-format` as a separate commit on larger changes, and review each modified hunk. 
-
-Either way, just ensure you manually review automatic changes.
 
 #### VSCode
 


### PR DESCRIPTION
Added version, installation, and verification steps for clang-format to help contributors avoid CI issues.