### PR TITLE
Document deprecation warning for 'getdata' method

### DIFF
--- a/scripts/generate_font.py
+++ b/scripts/generate_font.py
@@ -57,6 +57,10 @@ for char_y in range(NUM_VERT_CHARS):
         crop_area = (pix_x, pix_y, pix_x + CHAR_WIDTH, pix_y + CHAR_HEIGHT)
         
         pixel_block_img = img.crop(crop_area)
+        # Note: "getdata" is a deprecated call in recent versions of pillow in
+        # favor of "get_flattened_data". However, as of May 17, 2026 the CI uses
+        # an earlier version of pillow that doesn't have "get_flattened_data"
+        # You can safely ignore the deprecation warning when builing on your host
         pixels = list(pixel_block_img.getdata())
 
         word0 = 0


### PR DESCRIPTION
Added comments regarding the deprecation of 'getdata' in Pillow.

Comment in regards to: https://github.com/GBALATRO/balatro-gba/pull/486 . Good info for anyone seeing the warning.