### PR TITLE
[Bug] Fix applying boss blind color twice

### DIFF
--- a/include/blind.h
+++ b/include/blind.h
@@ -103,8 +103,6 @@ typedef struct
 
 void blind_init();
 
-void blind_set_boss_graphics(const unsigned int* tiles, const u16* palette);
-
 u32 blind_get_requirement(enum BlindType type, int ante);
 int blind_get_reward(enum BlindType type);
 u16 blind_get_color(enum BlindType type, enum BlindColorIndex index);

--- a/source/game.c
+++ b/source/game.c
@@ -1213,12 +1213,9 @@ void change_background_legacy(enum BackgroundId id)
             {
                 main_bg_se_copy_rect(BIG_BLIND_TITLE_SRC_RECT, TOP_LEFT_BLIND_TITLE_POINT);
             }
-            else if (g_game_vars.current_blind > BLIND_TYPE_BIG)
+            else if (g_game_vars.current_blind >= BLIND_TYPE_BOSS)
             {
                 main_bg_se_copy_rect(BOSS_BLIND_TITLE_SRC_RECT, TOP_LEFT_BLIND_TITLE_POINT);
-                affine_background_set_color(
-                    blind_get_color(g_game_vars.current_blind, BLIND_SHADOW_COLOR_INDEX)
-                );
             }
 
             bg_copy_current_item_to_top_left_panel();

--- a/source/game/blind_select.c
+++ b/source/game/blind_select.c
@@ -1,5 +1,6 @@
 #include "blind_select.h"
 
+#include "affine_background.h"
 #include "audio_utils.h"
 #include "background_blind_select_gfx.h"
 #include "blind.h"
@@ -279,6 +280,13 @@ static void game_blind_select_display_blind_panel()
         main_bg_se_copy_expand_3w_row(TOP_LEFT_PANEL_ANIM_RECT, TOP_LEFT_PANEL_EMPTY_3W_ROW_POS);
 
         reset_top_left_panel_bottom_row();
+
+        if (g_game_vars.current_blind >= BLIND_TYPE_BOSS)
+        {
+            affine_background_set_color(
+                blind_get_color(g_game_vars.current_blind, BLIND_SHADOW_COLOR_INDEX)
+            );
+        }
     }
 
     // Shift the blind panel down onto screen


### PR DESCRIPTION
So I encountered a weird bug that has flown under the radar for a long time despite being quite obvious ^^'

By calling `change_background(BG_CARD_SELECTING, false)` both at the end of the Blind Select screen, and at the beginning of the Playing state, we effectively applied the boss blind color twice to the affine background.

Notice how the background first changes color, then suddenly gets darker:

https://github.com/user-attachments/assets/6c3bc024-1008-43e7-8146-6bfb404129a7

I fixed it by applying the boss blind color to the background outside of the `change_background_legacy` function, at the end of the blind select screen if next blind is a boss/showdown. The background is significantly lighter as a result, with better colors:

https://github.com/user-attachments/assets/ba262584-db29-433f-8ae7-a2a6755c480a
