### PR TITLE
Refactor - Moved shop data structures to `shop.c/.h`

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -1,7 +1,6 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "bitset.h"
 #include "game/common_ui.h"
 #include "game_variables.h"
 #include "graphic_utils.h"
@@ -89,9 +88,6 @@ void remove_owned_joker(int owned_joker_idx);
 List* get_jokers_list(void);
 List* get_expired_jokers_list(void);
 List* get_discarded_jokers_list(void);
-List* get_shop_jokers_list(void);
-Bitset* get_avail_jokers_bitset(void);
-void set_shop_joker_avail(int joker_id, bool avail);
 
 int get_deck_top(void);
 int get_num_discards_remaining(void);

--- a/include/game/shop.h
+++ b/include/game/shop.h
@@ -16,8 +16,8 @@ void game_shop_init_run(void);
 
 /**
  * @brief Set whether a Joker can appear in the shop.
- * 
- * @param avail - true to make it available to appear in the shop
+ *
+ * @param avail - true to make it available to the shop to appear in
  *                false to make it unavailable.
  */
 void game_shop_set_joker_avail(int joker_id, bool avail);

--- a/include/game/shop.h
+++ b/include/game/shop.h
@@ -12,7 +12,7 @@
  * @brief Initialize the shop for a run.
  * Resets all the shop data for the run, needs to be called once per run.
  */
-void game_shop_init_run(void);
+void game_shop_reset(void);
 
 /**
  * @brief Set whether a Joker can appear in the shop.

--- a/include/game/shop.h
+++ b/include/game/shop.h
@@ -6,6 +6,22 @@
 #ifndef GAME_SHOP_H
 #define GAME_SHOP_H
 
+#include <stdbool.h>
+
+/**
+ * @brief Initialize the shop for a run.
+ * Resets all the shop data for the run, needs to be called once per run.
+ */
+void game_shop_init_run(void);
+
+/**
+ * @brief Set whether a Joker can appear in the shop.
+ * 
+ * @param avail - true to make it available to appear in the shop
+ *                false to make it unavailable.
+ */
+void game_shop_set_joker_avail(int joker_id, bool avail);
+
 /**
  * @brief Change to the shop background
  */

--- a/source/game.c
+++ b/source/game.c
@@ -318,9 +318,6 @@ static List _owned_jokers_list;
 static List _discarded_jokers_list;
 static List _expired_jokers_list;
 
-BITSET_DEFINE(_avail_jokers_bitset, MAX_DEFINABLE_JOKERS)
-static List _shop_jokers_list;
-
 // Stacks
 static CardObject* played[MAX_SELECTION_SIZE] = {NULL};
 static int played_top = -1;
@@ -335,22 +332,6 @@ static int discard_top = -1;
 static int shortcut_joker_count = 0;
 
 static int four_fingers_joker_count = 0;
-
-GBAL_UNUSED
-static inline bool is_shop_joker_avail(int joker_id)
-{
-    return bitset_get_idx(&_avail_jokers_bitset, joker_id);
-}
-
-static inline void reset_shop_jokers(void)
-{
-    int num_jokers = get_joker_registry_size();
-    bitset_clear(&_avail_jokers_bitset);
-    for (int i = 0; i < num_jokers; i++)
-    {
-        bitset_set_idx(&_avail_jokers_bitset, i, true);
-    }
-}
 
 static inline void played_push(CardObject* card_object)
 {
@@ -394,11 +375,6 @@ static inline Card* discard_pop()
     return discard_pile[discard_top--];
 }
 
-static inline void jokers_available_to_shop_init(void)
-{
-    reset_shop_jokers();
-}
-
 void game_init()
 {
     state_machine_remove(&game_sm);
@@ -407,11 +383,10 @@ void game_init()
     _owned_jokers_list = list_init();
     _discarded_jokers_list = list_init();
     _expired_jokers_list = list_init();
-    _shop_jokers_list = list_init();
     // TODO: Move this to an initialization of the play scoring states
     _joker_scored_itr = list_itr_create(&_owned_jokers_list);
 
-    jokers_available_to_shop_init();
+    game_shop_init_run();
 
     g_game_vars.hands = MAX_HANDS;
     g_game_vars.discards = MAX_DISCARDS;
@@ -450,7 +425,6 @@ void game_reset()
     list_clear(&_owned_jokers_list);
     list_clear(&_discarded_jokers_list);
     list_clear(&_expired_jokers_list);
-    list_clear(&_shop_jokers_list);
 
     game_init();
 
@@ -628,21 +602,6 @@ List* get_discarded_jokers_list(void)
     return &_discarded_jokers_list;
 }
 
-List* get_shop_jokers_list(void)
-{
-    return &_shop_jokers_list;
-}
-
-Bitset* get_avail_jokers_bitset(void)
-{
-    return &_avail_jokers_bitset;
-}
-
-void set_shop_joker_avail(int joker_id, bool avail)
-{
-    bitset_set_idx(&_avail_jokers_bitset, joker_id, avail);
-}
-
 bool is_shortcut_joker_active(void)
 {
     return shortcut_joker_count > 0;
@@ -688,7 +647,7 @@ void remove_owned_joker(int owned_joker_idx)
         shortcut_joker_count--;
     }
 
-    set_shop_joker_avail(joker_object->joker->id, true);
+    game_shop_set_joker_avail(joker_object->joker->id, true);
     list_remove_at_idx(&_owned_jokers_list, owned_joker_idx);
 }
 

--- a/source/game.c
+++ b/source/game.c
@@ -386,7 +386,7 @@ void game_init()
     // TODO: Move this to an initialization of the play scoring states
     _joker_scored_itr = list_itr_create(&_owned_jokers_list);
 
-    game_shop_init_run();
+    game_shop_reset();
 
     g_game_vars.hands = MAX_HANDS;
     g_game_vars.discards = MAX_DISCARDS;

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -63,6 +63,9 @@ static const Rect     SHOP_REROLL_RECT      = { 88,  96, UNDEFINED, UNDEFINED };
 static const BG_POINT SHOP_JOKER_SPRITES_INIT_POS = {120, 160};
 // clang-format on
 
+static List _shop_jokers_list = LIST_DEFAULT;
+BITSET_DEFINE(_avail_jokers_bitset, MAX_DEFINABLE_JOKERS)
+
 enum GameShopStates
 {
     GAME_SHOP_INTRO,
@@ -136,6 +139,32 @@ static int timer;
 
 static int reroll_cost = REROLL_BASE_COST;
 
+static inline void reset_shop_jokers(void)
+{
+    int num_jokers = get_joker_registry_size();
+
+    bitset_clear(&_avail_jokers_bitset);
+    for (int i = 0; i < num_jokers; i++)
+    {
+        bitset_set_idx(&_avail_jokers_bitset, i, true);
+    }
+}
+
+void game_shop_init_run(void)
+{
+    list_clear(&_shop_jokers_list);
+    _shop_jokers_list = list_init();
+    reset_shop_jokers();
+}
+
+/**
+ * @brief Set whether a Joker can appear in the shop.
+ */
+void game_shop_set_joker_avail(int joker_id, bool avail)
+{
+    bitset_set_idx(&_avail_jokers_bitset, joker_id, avail);
+}
+
 void game_shop_change_background(void)
 {
     toggle_windows(false, true);
@@ -181,7 +210,7 @@ void game_shop_on_init(void)
  */
 static inline int get_num_shop_jokers_avail(void)
 {
-    return bitset_num_set_bits(get_avail_jokers_bitset());
+    return bitset_num_set_bits(&_avail_jokers_bitset);
 }
 
 /**
@@ -203,7 +232,7 @@ static inline int game_shop_get_rand_available_joker_id(void)
     int fallback_random_joker_id = UNDEFINED;
     int match_count = 0;
 
-    BitsetItr itr = bitset_itr_create(get_avail_jokers_bitset());
+    BitsetItr itr = bitset_itr_create(&_avail_jokers_bitset);
 
     int i = 0;
     int joker_id = UNDEFINED;
@@ -229,7 +258,14 @@ static inline int game_shop_get_rand_available_joker_id(void)
  */
 static inline bool no_avail_jokers(void)
 {
-    return bitset_is_empty(get_avail_jokers_bitset());
+    return bitset_is_empty(&_avail_jokers_bitset);
+}
+
+
+GBAL_UNUSED
+static inline bool is_shop_joker_avail(int joker_id)
+{
+    return bitset_get_idx(&_avail_jokers_bitset, joker_id);
 }
 
 /**
@@ -244,7 +280,7 @@ static void game_shop_create_items(void)
     if (no_avail_jokers())
         return;
 
-    List* shop_jokers_list = get_shop_jokers_list();
+    List* shop_jokers_list = &_shop_jokers_list;
 
     list_clear(shop_jokers_list);
     *shop_jokers_list = list_init();
@@ -274,7 +310,7 @@ static void game_shop_create_items(void)
         if (joker_id == UNDEFINED)
             break;
 
-        set_shop_joker_avail(joker_id, false);
+        game_shop_set_joker_avail(joker_id, false);
 
         JokerObject* joker_object = joker_object_new(joker_new(joker_id));
 
@@ -349,7 +385,7 @@ static void game_shop_intro()
 static int shop_top_row_get_size(void)
 {
     // + 1 to account for next round button
-    return list_get_len(get_shop_jokers_list()) + 1;
+    return list_get_len(&_shop_jokers_list) + 1;
 }
 
 /**
@@ -366,7 +402,7 @@ static inline void add_to_held_jokers(JokerObject* joker_object)
  */
 static inline void game_shop_buy_joker(int shop_joker_idx)
 {
-    List* shop_jokers_list = get_shop_jokers_list();
+    List* shop_jokers_list = &_shop_jokers_list;
     JokerObject* joker_object = (JokerObject*)list_get_at_idx(shop_jokers_list, shop_joker_idx);
 
     g_game_vars.money -= joker_object->joker->value;
@@ -393,7 +429,7 @@ static void shop_top_row_on_key_transit(SelectionGrid* selection_grid, Selection
     {
         int shop_joker_idx = selection->x - 1; // - 1 to account for next round button
         JokerObject* joker_object =
-            (JokerObject*)list_get_at_idx(get_shop_jokers_list(), shop_joker_idx);
+            (JokerObject*)list_get_at_idx(&_shop_jokers_list, shop_joker_idx);
         if (joker_object == NULL || list_get_len(get_jokers_list()) >= MAX_JOKERS_HELD_SIZE ||
             g_game_vars.money < joker_object->joker->value)
         {
@@ -415,7 +451,7 @@ static bool shop_top_row_on_selection_changed(
     const Selection* new_selection
 )
 {
-    List* shop_jokers_list = get_shop_jokers_list();
+    List* shop_jokers_list = &_shop_jokers_list;
     // Guard if we move down while on jokers
     if (new_selection->y > row_idx && prev_selection->x > 0)
         return false;
@@ -482,7 +518,7 @@ static bool shop_reroll_row_on_selection_changed(
         if (new_selection->x != NEXT_ROUND_BTN_SEL_X)
         {
             int idx = new_selection->x - 1;
-            JokerObject* joker_object = (JokerObject*)list_get_at_idx(get_shop_jokers_list(), idx);
+            JokerObject* joker_object = (JokerObject*)list_get_at_idx(&_shop_jokers_list, idx);
             sprite_object_set_focus(joker_object->sprite_object, true);
         }
     }
@@ -503,7 +539,7 @@ static inline void game_shop_reroll(int* reroll_cost)
     g_game_vars.money -= *reroll_cost;
     display_money(); // Update the money display
 
-    List* shop_jokers_list = get_shop_jokers_list();
+    List* shop_jokers_list = &_shop_jokers_list;
     ListItr itr = list_itr_create(shop_jokers_list);
     JokerObject* joker_object;
 
@@ -511,7 +547,7 @@ static inline void game_shop_reroll(int* reroll_cost)
     {
         if (joker_object != NULL)
         {
-            set_shop_joker_avail(joker_object->joker->id, true);
+            game_shop_set_joker_avail(joker_object->joker->id, true);
             joker_object_destroy(&joker_object); // Destroy the joker object if it exists
         }
     }
@@ -604,7 +640,7 @@ static void game_shop_outro()
     {
         tte_erase_rect_wrapper(SHOP_PRICES_TEXT_RECT); // Erase the shop prices text
 
-        ListItr itr = list_itr_create(get_shop_jokers_list());
+        ListItr itr = list_itr_create(&_shop_jokers_list);
         JokerObject* joker_object;
         while ((joker_object = list_itr_next(&itr)))
         {
@@ -663,7 +699,7 @@ void game_shop_on_update(void)
 {
     timer++;
 
-    List* shop_jokers_list = get_shop_jokers_list();
+    List* shop_jokers_list = &_shop_jokers_list;
 
     if (!list_is_empty(shop_jokers_list))
     {
@@ -686,7 +722,7 @@ void game_shop_on_update(void)
 
 void game_shop_on_exit(void)
 {
-    List* shop_jokers_list = get_shop_jokers_list();
+    List* shop_jokers_list = &_shop_jokers_list;
     ListItr itr = list_itr_create(shop_jokers_list);
     JokerObject* joker_object;
 
@@ -695,7 +731,7 @@ void game_shop_on_exit(void)
         if (joker_object != NULL)
         {
             // Make the joker available back to shop
-            set_shop_joker_avail(joker_object->joker->id, true);
+            game_shop_set_joker_avail(joker_object->joker->id, true);
         }
         joker_object_destroy(&joker_object); // Destroy the joker objects
     }

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -261,7 +261,6 @@ static inline bool no_avail_jokers(void)
     return bitset_is_empty(&_avail_jokers_bitset);
 }
 
-
 GBAL_UNUSED
 static inline bool is_shop_joker_avail(int joker_id)
 {

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -63,8 +63,8 @@ static const Rect     SHOP_REROLL_RECT      = { 88,  96, UNDEFINED, UNDEFINED };
 static const BG_POINT SHOP_JOKER_SPRITES_INIT_POS = {120, 160};
 // clang-format on
 
-static List _shop_jokers_list = LIST_DEFAULT;
-BITSET_DEFINE(_avail_jokers_bitset, MAX_DEFINABLE_JOKERS)
+static List s_shop_jokers_list = LIST_DEFAULT;
+BITSET_DEFINE(s_avail_jokers_bitset, MAX_DEFINABLE_JOKERS)
 
 enum GameShopStates
 {
@@ -143,17 +143,17 @@ static inline void reset_shop_jokers(void)
 {
     int num_jokers = get_joker_registry_size();
 
-    bitset_clear(&_avail_jokers_bitset);
+    bitset_clear(&s_avail_jokers_bitset);
     for (int i = 0; i < num_jokers; i++)
     {
-        bitset_set_idx(&_avail_jokers_bitset, i, true);
+        bitset_set_idx(&s_avail_jokers_bitset, i, true);
     }
 }
 
-void game_shop_init_run(void)
+void game_shop_reset(void)
 {
-    list_clear(&_shop_jokers_list);
-    _shop_jokers_list = list_init();
+    list_clear(&s_shop_jokers_list);
+    s_shop_jokers_list = list_init();
     reset_shop_jokers();
 }
 
@@ -162,7 +162,7 @@ void game_shop_init_run(void)
  */
 void game_shop_set_joker_avail(int joker_id, bool avail)
 {
-    bitset_set_idx(&_avail_jokers_bitset, joker_id, avail);
+    bitset_set_idx(&s_avail_jokers_bitset, joker_id, avail);
 }
 
 void game_shop_change_background(void)
@@ -210,7 +210,7 @@ void game_shop_on_init(void)
  */
 static inline int get_num_shop_jokers_avail(void)
 {
-    return bitset_num_set_bits(&_avail_jokers_bitset);
+    return bitset_num_set_bits(&s_avail_jokers_bitset);
 }
 
 /**
@@ -232,7 +232,7 @@ static inline int game_shop_get_rand_available_joker_id(void)
     int fallback_random_joker_id = UNDEFINED;
     int match_count = 0;
 
-    BitsetItr itr = bitset_itr_create(&_avail_jokers_bitset);
+    BitsetItr itr = bitset_itr_create(&s_avail_jokers_bitset);
 
     int i = 0;
     int joker_id = UNDEFINED;
@@ -258,13 +258,13 @@ static inline int game_shop_get_rand_available_joker_id(void)
  */
 static inline bool no_avail_jokers(void)
 {
-    return bitset_is_empty(&_avail_jokers_bitset);
+    return bitset_is_empty(&s_avail_jokers_bitset);
 }
 
 GBAL_UNUSED
 static inline bool is_shop_joker_avail(int joker_id)
 {
-    return bitset_get_idx(&_avail_jokers_bitset, joker_id);
+    return bitset_get_idx(&s_avail_jokers_bitset, joker_id);
 }
 
 /**
@@ -279,7 +279,7 @@ static void game_shop_create_items(void)
     if (no_avail_jokers())
         return;
 
-    List* shop_jokers_list = &_shop_jokers_list;
+    List* shop_jokers_list = &s_shop_jokers_list;
 
     list_clear(shop_jokers_list);
     *shop_jokers_list = list_init();
@@ -384,7 +384,7 @@ static void game_shop_intro()
 static int shop_top_row_get_size(void)
 {
     // + 1 to account for next round button
-    return list_get_len(&_shop_jokers_list) + 1;
+    return list_get_len(&s_shop_jokers_list) + 1;
 }
 
 /**
@@ -401,7 +401,7 @@ static inline void add_to_held_jokers(JokerObject* joker_object)
  */
 static inline void game_shop_buy_joker(int shop_joker_idx)
 {
-    List* shop_jokers_list = &_shop_jokers_list;
+    List* shop_jokers_list = &s_shop_jokers_list;
     JokerObject* joker_object = (JokerObject*)list_get_at_idx(shop_jokers_list, shop_joker_idx);
 
     g_game_vars.money -= joker_object->joker->value;
@@ -428,7 +428,7 @@ static void shop_top_row_on_key_transit(SelectionGrid* selection_grid, Selection
     {
         int shop_joker_idx = selection->x - 1; // - 1 to account for next round button
         JokerObject* joker_object =
-            (JokerObject*)list_get_at_idx(&_shop_jokers_list, shop_joker_idx);
+            (JokerObject*)list_get_at_idx(&s_shop_jokers_list, shop_joker_idx);
         if (joker_object == NULL || list_get_len(get_jokers_list()) >= MAX_JOKERS_HELD_SIZE ||
             g_game_vars.money < joker_object->joker->value)
         {
@@ -450,7 +450,7 @@ static bool shop_top_row_on_selection_changed(
     const Selection* new_selection
 )
 {
-    List* shop_jokers_list = &_shop_jokers_list;
+    List* shop_jokers_list = &s_shop_jokers_list;
     // Guard if we move down while on jokers
     if (new_selection->y > row_idx && prev_selection->x > 0)
         return false;
@@ -517,7 +517,7 @@ static bool shop_reroll_row_on_selection_changed(
         if (new_selection->x != NEXT_ROUND_BTN_SEL_X)
         {
             int idx = new_selection->x - 1;
-            JokerObject* joker_object = (JokerObject*)list_get_at_idx(&_shop_jokers_list, idx);
+            JokerObject* joker_object = (JokerObject*)list_get_at_idx(&s_shop_jokers_list, idx);
             sprite_object_set_focus(joker_object->sprite_object, true);
         }
     }
@@ -538,7 +538,7 @@ static inline void game_shop_reroll(int* reroll_cost)
     g_game_vars.money -= *reroll_cost;
     display_money(); // Update the money display
 
-    List* shop_jokers_list = &_shop_jokers_list;
+    List* shop_jokers_list = &s_shop_jokers_list;
     ListItr itr = list_itr_create(shop_jokers_list);
     JokerObject* joker_object;
 
@@ -639,7 +639,7 @@ static void game_shop_outro()
     {
         tte_erase_rect_wrapper(SHOP_PRICES_TEXT_RECT); // Erase the shop prices text
 
-        ListItr itr = list_itr_create(&_shop_jokers_list);
+        ListItr itr = list_itr_create(&s_shop_jokers_list);
         JokerObject* joker_object;
         while ((joker_object = list_itr_next(&itr)))
         {
@@ -698,7 +698,7 @@ void game_shop_on_update(void)
 {
     timer++;
 
-    List* shop_jokers_list = &_shop_jokers_list;
+    List* shop_jokers_list = &s_shop_jokers_list;
 
     if (!list_is_empty(shop_jokers_list))
     {
@@ -721,7 +721,7 @@ void game_shop_on_update(void)
 
 void game_shop_on_exit(void)
 {
-    List* shop_jokers_list = &_shop_jokers_list;
+    List* shop_jokers_list = &s_shop_jokers_list;
     ListItr itr = list_itr_create(shop_jokers_list);
     JokerObject* joker_object;
 


### PR DESCRIPTION
Since `_shop_jokers_list` and `_avail_jokers_bitset` are mainly used by the shop, it makes more sense to put them in `shop.c/.h`  and have the shop module manage them instead of having them in `game.c/.h` with getters for the shop.