### PR TITLE
Clarify Linux installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,9 @@ Disregard Steps 4-5 and instead click the green code button on the main reposito
 
 ### Linux (Debian/Arch)
 
-These instructions will be only for Debian (**Ubuntu**) and Arch based systems. 
+These instructions will be only for Debian (**Ubuntu**) and Arch based systems.
+
+**Note:** _Ubuntu based distros require version >= 24.04_.
 
 1.) Follow the devkitPro Pacman installation guide for distro:   https://devkitpro.org/wiki/devkitPro_pacman
 - On **Debian** systems it will be installed as **`dkp-pacman`**.


### PR DESCRIPTION
Added note about Ubuntu version requirements for installation. A friend recently tried it on PopOS 22.04 and we found out the glibc version is incompatible with (2.36 required, 2.35 provided). This technically is related to only devkitpro, but it couldn't hurt to note here. 