### PR TITLE
Removed dubious SpriteObject cast from long ago

### DIFF
--- a/source/joker.c
+++ b/source/joker.c
@@ -231,8 +231,7 @@ void joker_object_destroy(JokerObject** joker_object)
 
 void joker_object_update(JokerObject* joker_object)
 {
-    CardObject* card_object = (CardObject*)joker_object;
-    card_object_update(card_object);
+    sprite_object_update(joker_object->sprite_object);
 }
 
 void joker_object_shake(JokerObject* joker_object, mm_word sound_id)


### PR DESCRIPTION
So while working on #533 and #536 I realized there was a cast I meant to fix and missed back when I introduced `SpriteObject` in #63 and actually this is one of the very reasons I introduced it. 🤣
So the cast has been working so far, but just because `CardObject` works, `JokerObject` should in no way depend on `CardObject`.