### PR TITLE
Cleanup sprite_position usage

### DIFF
--- a/source/game.c
+++ b/source/game.c
@@ -1357,7 +1357,6 @@ static inline void card_draw(void)
 
     card_object->sprite_object->x = deck_x;
     card_object->sprite_object->y = deck_y;
-    sprite_position(card_object->sprite_object->sprite, fx2int(deck_x), fx2int(deck_y));
 
     set_hand_top(get_hand_top() + 1);
     get_hand_array()[get_hand_top()] = card_object;
@@ -2356,11 +2355,6 @@ static inline void cards_in_hand_update_loop(void)
                     if (i != selected_card_idx && hand[i]->sprite_object->y > hand_y)
                     {
                         hand[i]->sprite_object->y = hand_y;
-                        sprite_position(
-                            hand[i]->sprite_object->sprite,
-                            fx2int(hand[i]->sprite_object->x),
-                            fx2int(hand_y)
-                        );
                         // Set target y to match y. Ensures target is updated even when vy becomes
                         // 0, preventing immediate snap back.
                         hand[i]->sprite_object->ty = hand_y;

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -321,12 +321,6 @@ static void game_shop_create_items(void)
 
         sprite_object_print_price_under(joker_object->sprite_object, joker_object->joker->value);
 
-        sprite_position(
-            joker_object_get_sprite(joker_object),
-            fx2int(joker_object->sprite_object->x),
-            fx2int(joker_object->sprite_object->y)
-        );
-
         list_push_back(shop_jokers_list, joker_object);
     }
 }

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -226,11 +226,8 @@ static inline bool is_sprite_object_static(const SpriteObject* sprite_object)
     return !sprite_object_has_velocity(sprite_object) && sprite_object_at_target(sprite_object);
 }
 
-IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
+static inline void update_sprite_position(SpriteObject* sprite_object)
 {
-    if (is_sprite_object_static(sprite_object))
-        return;
-
     sprite_object->vx += ((sprite_object->tx - sprite_object->x) * g_game_vars.game_speed) / 8;
     sprite_object->vy += ((sprite_object->ty - sprite_object->y) * g_game_vars.game_speed) / 8;
 
@@ -297,6 +294,13 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
         sprite_object->scale,
         -sprite_object->vx + sprite_object->rotation
     );
+}
+
+IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
+{
+    if (!is_sprite_object_static(sprite_object))
+        update_sprite_position(sprite_object);
+
     sprite_position(sprite_object->sprite, fx2int(sprite_object->x), fx2int(sprite_object->y));
 }
 

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -226,7 +226,7 @@ static inline bool is_sprite_object_static(const SpriteObject* sprite_object)
     return !sprite_object_has_velocity(sprite_object) && sprite_object_at_target(sprite_object);
 }
 
-static inline void update_sprite_position(SpriteObject* sprite_object)
+static inline IWRAM_CODE void update_sprite_position(SpriteObject* sprite_object)
 {
     sprite_object->vx += ((sprite_object->tx - sprite_object->x) * g_game_vars.game_speed) / 8;
     sprite_object->vy += ((sprite_object->ty - sprite_object->y) * g_game_vars.game_speed) / 8;


### PR DESCRIPTION
Closes #487 

Reduce the `sprite_position` calls for `SpriteObject`'s. Additionally adjust the `sprite_object_update()` call to be more readable.