### PR TITLE
[Bug] Fix missing Deck size/max text after showing Joker description in the Shop

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -96,6 +96,7 @@ int get_deck_top(void);
 int get_num_discards_remaining(void);
 int get_num_hands_remaining(void);
 
+void display_deck_size_max(void);
 u32 get_chips(void);
 void set_chips(u32 new_chips);
 void display_chips(void);

--- a/source/game.c
+++ b/source/game.c
@@ -773,6 +773,21 @@ void display_mult(void)
     check_flaming_score();
 }
 
+void display_deck_size_max(void)
+{
+    // TODO: the text will overflow if deck max size exceeds 99,
+    // we will need a fix at some point for this
+    tte_erase_rect_wrapper(DECK_SIZE_RECT);
+    tte_printf(
+        "#{P:%d,%d; cx:0x%X000}%d/%d",
+        DECK_SIZE_RECT.left,
+        DECK_SIZE_RECT.top,
+        TTE_WHITE_PB,
+        deck_get_size(),
+        deck_get_max_size()
+    );
+}
+
 // Returns true if the card is *considered* a face card
 bool card_is_face(Card* card)
 {
@@ -2477,17 +2492,7 @@ static inline void game_playing_ui_text_update(void)
         }
 
         // Deck size/max size
-        // TODO: the text will overflow if deck max size exceeds 99,
-        // we will need a fix at some point for this
-        tte_erase_rect_wrapper(DECK_SIZE_RECT);
-        tte_printf(
-            "#{P:%d,%d; cx:0x%X000}%d/%d",
-            DECK_SIZE_RECT.left,
-            DECK_SIZE_RECT.top,
-            TTE_WHITE_PB,
-            deck_get_size(),
-            deck_get_max_size()
-        );
+        display_deck_size_max();
 
         last_hand_size = hand_nb_held_cards();
         last_deck_size = deck_get_size();

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -893,6 +893,9 @@ static void game_shop_hide_card_desc(void)
             TTE_WHITE_PB,
             reroll_cost
         );
+
+        // Print Deck size that was erased
+        display_deck_size_max();
     }
 
     // Cleanup and change state


### PR DESCRIPTION
I noticed it earlier, but when showing a Joker's description I clean the right part of the screen from top to bottom, but after hiding the description I forgot to display that text again. This should now be done ^^

https://github.com/user-attachments/assets/b0748dd3-83b4-4289-b7b7-ba68ed68ca64

I'm adding this to the v0.2.0 milestone since this is a bug related to one of the main features of that release.