### PR TITLE
Implement a global SpriteObject update loop

### DIFF
--- a/include/card.h
+++ b/include/card.h
@@ -75,7 +75,6 @@ u8 card_get_value(Card* card);
 // CardObject methods
 CardObject* card_object_new(Card* card);
 void card_object_destroy(CardObject** card_object);
-void card_object_update(CardObject* card_object); // Update the card object position and scale
 void card_object_set_sprite(CardObject* card_object, int layer);
 void card_object_set_sprite_face_down(CardObject* card_object, enum DeckType deck, int layer);
 void card_object_shake(CardObject* card_object, mm_word sound_id);

--- a/include/joker.h
+++ b/include/joker.h
@@ -195,7 +195,6 @@ int joker_get_sell_value(const Joker* joker);
 
 JokerObject* joker_object_new(Joker* joker);
 void joker_object_destroy(JokerObject** joker_object);
-void joker_object_update(JokerObject* joker_object);
 // This doesn't actually score anything, it just performs an animation and plays a sound effect
 void joker_object_shake(JokerObject* joker_object, mm_word sound_id);
 // This scores the joker and returns true if it was scored successfully

--- a/include/pool.h
+++ b/include/pool.h
@@ -62,9 +62,9 @@
 
 #define POOL_GET(type)           pool_get_##type()
 #define POOL_FREE(type, obj)     pool_free_##type(obj)
-#define POOL_IDX(type, obj)      pool_idx_##type(obj) // the index of the object
-#define POOL_AT(type, idx)       pool_at_##type(idx)  // the object at
-#define POOL_VALID_AT(type, idx) pool_valid_at_##type(idx)  // the object at idx is currently valid
+#define POOL_IDX(type, obj)      pool_idx_##type(obj)      // the index of the object
+#define POOL_AT(type, idx)       pool_at_##type(idx)       // the object at
+#define POOL_VALID_AT(type, idx) pool_valid_at_##type(idx) // the object at idx is currently valid
 
 #define POOL_ENTRY(name, capacity) POOL_DECLARE_TYPE(name);
 #include POOLS_DEF_FILE

--- a/include/pool.h
+++ b/include/pool.h
@@ -21,8 +21,7 @@
     type* pool_get_##type();          \
     void pool_free_##type(type* obj); \
     int pool_idx_##type(type* obj);   \
-    type* pool_at_##type(int idx);    \
-    bool pool_valid_at_##type(int idx);
+    type* pool_at_##type(int idx);
 
 #define POOL_DEFINE_TYPE(type, capacity)                                \
     BITSET_DEFINE(type##_bitset, capacity)                              \

--- a/include/pool.h
+++ b/include/pool.h
@@ -21,7 +21,8 @@
     type* pool_get_##type();          \
     void pool_free_##type(type* obj); \
     int pool_idx_##type(type* obj);   \
-    type* pool_at_##type(int idx);
+    type* pool_at_##type(int idx);    \
+    bool pool_valid_at_##type(int idx);
 
 #define POOL_DEFINE_TYPE(type, capacity)                                \
     BITSET_DEFINE(type##_bitset, capacity)                              \
@@ -53,12 +54,17 @@
         if (idx < 0 || idx >= (type##_pool.bitset)->cap)                \
             return NULL;                                                \
         return &type##_pool.objects[idx];                               \
+    }                                                                   \
+    bool pool_valid_at_##type(int idx)                                  \
+    {                                                                   \
+        return bitset_get_idx(type##_pool.bitset, idx);                 \
     }
 
-#define POOL_GET(type)       pool_get_##type()
-#define POOL_FREE(type, obj) pool_free_##type(obj)
-#define POOL_IDX(type, obj)  pool_idx_##type(obj) // the index of the object
-#define POOL_AT(type, idx)   pool_at_##type(idx)  // the object at
+#define POOL_GET(type)           pool_get_##type()
+#define POOL_FREE(type, obj)     pool_free_##type(obj)
+#define POOL_IDX(type, obj)      pool_idx_##type(obj) // the index of the object
+#define POOL_AT(type, idx)       pool_at_##type(idx)  // the object at
+#define POOL_VALID_AT(type, idx) pool_valid_at_##type(idx)  // the object at idx is currently valid
 
 #define POOL_ENTRY(name, capacity) POOL_DECLARE_TYPE(name);
 #include POOLS_DEF_FILE

--- a/include/pool.h
+++ b/include/pool.h
@@ -54,17 +54,12 @@
         if (idx < 0 || idx >= (type##_pool.bitset)->cap)                \
             return NULL;                                                \
         return &type##_pool.objects[idx];                               \
-    }                                                                   \
-    bool pool_valid_at_##type(int idx)                                  \
-    {                                                                   \
-        return bitset_get_idx(type##_pool.bitset, idx);                 \
     }
 
-#define POOL_GET(type)           pool_get_##type()
-#define POOL_FREE(type, obj)     pool_free_##type(obj)
-#define POOL_IDX(type, obj)      pool_idx_##type(obj)      // the index of the object
-#define POOL_AT(type, idx)       pool_at_##type(idx)       // the object at
-#define POOL_VALID_AT(type, idx) pool_valid_at_##type(idx) // the object at idx is currently valid
+#define POOL_GET(type)       pool_get_##type()
+#define POOL_FREE(type, obj) pool_free_##type(obj)
+#define POOL_IDX(type, obj)  pool_idx_##type(obj) // the index of the object
+#define POOL_AT(type, idx)   pool_at_##type(idx)  // the object at
 
 #define POOL_ENTRY(name, capacity) POOL_DECLARE_TYPE(name);
 #include POOLS_DEF_FILE

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -240,6 +240,8 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object);
 
 /**
  * @brief Update all SpriteObjects, to be called once per frame in the main update loop.
+ *
+ * TODO: try and put this function in IWRAM for performance purposes. Crashed the last time I tried.
  */
 void sprite_object_update_all(void);
 

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -241,7 +241,7 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object);
 /**
  * @brief Update all SpriteObjects, to be called once per frame in the main update loop.
  */
-IWRAM_CODE void sprite_object_update_all(void);
+void sprite_object_update_all(void);
 
 /**
  * @brief Shake SpriteObject on screen and play a sound

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -239,6 +239,11 @@ void sprite_object_reset_transform(SpriteObject* sprite_object);
 IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object);
 
 /**
+ * @brief Update all SpriteObjects, to be called once per frame in the main update loop.
+ */
+IWRAM_CODE void sprite_object_update_all(void);
+
+/**
  * @brief Shake SpriteObject on screen and play a sound
  *
  * @param SpriteObject pointer to SpriteObject to shake. Cannot be **NULL**.

--- a/source/card.c
+++ b/source/card.c
@@ -118,13 +118,6 @@ void card_object_destroy(CardObject** card_object)
     *card_object = NULL;
 }
 
-void card_object_update(CardObject* card_object)
-{
-    if (card_object == NULL)
-        return;
-    sprite_object_update(card_object->sprite_object);
-}
-
 void card_object_set_sprite(CardObject* card_object, int layer)
 {
     int tile_index = CARD_TID + (layer * CARD_SPRITE_OFFSET);

--- a/source/game.c
+++ b/source/game.c
@@ -195,7 +195,7 @@ static const Rect DECK_SIZE_RECT            = {200,     152,    240,       160  
 static const Rect ROUND_TEXT_RECT           = {48,      144,    UNDEFINED, UNDEFINED };
 static const Rect ANTE_TEXT_RECT            = {8,       144,    UNDEFINED, UNDEFINED };
 
-static const BG_POINT CARD_DRAW_POS         = {210,     118};
+static const BG_POINT CARD_DRAW_POS         = {208,     118};
 static const BG_POINT CARD_DISCARD_PNT      = {240,     70};
 static const BG_POINT HAND_START_POS        = {120,     90};
 static const BG_POINT HAND_PLAY_POS         = {120,     70};

--- a/source/game.c
+++ b/source/game.c
@@ -549,10 +549,11 @@ void game_update()
 
     g_game_vars.timer++;
 
-    sprite_object_update_all();
     jokers_update_loop();
 
     state_machine_update();
+
+    sprite_object_update_all();
 }
 
 void game_change_state(enum GameState new_game_state)
@@ -2258,9 +2259,6 @@ static inline void game_playing_discarded_cards_loop(void)
             discarded_card_object->sprite_object->ty = int2fx(112);
             discarded_card_object->sprite_object->x = int2fx(240);
             discarded_card_object->sprite_object->y = int2fx(80);
-
-            // Update immediately to avoid flickering sprites at position (0,0)
-            sprite_object_update(discarded_card_object->sprite_object);
         }
         else
         {

--- a/source/game.c
+++ b/source/game.c
@@ -195,7 +195,7 @@ static const Rect DECK_SIZE_RECT            = {200,     152,    240,       160  
 static const Rect ROUND_TEXT_RECT           = {48,      144,    UNDEFINED, UNDEFINED };
 static const Rect ANTE_TEXT_RECT            = {8,       144,    UNDEFINED, UNDEFINED };
 
-static const BG_POINT CARD_DRAW_POS         = {204,     114};
+static const BG_POINT CARD_DRAW_POS         = {210,     118};
 static const BG_POINT CARD_DISCARD_PNT      = {240,     70};
 static const BG_POINT HAND_START_POS        = {120,     90};
 static const BG_POINT HAND_PLAY_POS         = {120,     70};

--- a/source/game.c
+++ b/source/game.c
@@ -195,7 +195,7 @@ static const Rect DECK_SIZE_RECT            = {200,     152,    240,       160  
 static const Rect ROUND_TEXT_RECT           = {48,      144,    UNDEFINED, UNDEFINED };
 static const Rect ANTE_TEXT_RECT            = {8,       144,    UNDEFINED, UNDEFINED };
 
-static const BG_POINT CARD_DRAW_POS         = {208,     110};
+static const BG_POINT CARD_DRAW_POS         = {204,     114};
 static const BG_POINT CARD_DISCARD_PNT      = {240,     70};
 static const BG_POINT HAND_START_POS        = {120,     90};
 static const BG_POINT HAND_PLAY_POS         = {120,     70};
@@ -467,7 +467,6 @@ static inline void discarded_jokers_update_loop(void)
 
     while ((joker_object = list_itr_next(&itr)))
     {
-        joker_object_update(joker_object);
         if (joker_object->sprite_object->x == joker_object->sprite_object->tx &&
             joker_object->sprite_object->y == joker_object->sprite_object->ty)
         {
@@ -499,7 +498,6 @@ static inline void held_jokers_update_loop(void)
         if (joker != game_shop_get_description_card())
             joker->sprite_object->tx = hand_x - int2fx(spacing_lut[jokers_top][i]);
         i++;
-        joker_object_update(joker);
     }
 }
 
@@ -515,8 +513,6 @@ static inline void expired_jokers_update_loop(void)
 
     while ((joker_object = list_itr_next(&itr)))
     {
-        joker_object_update(joker_object);
-
         // let just enough frames pass that we see it rotating and shrinking
         if (g_game_vars.timer % FRAMES(EXPIRE_ANIMATION_FRAME_COUNT) == 0)
         {
@@ -553,6 +549,7 @@ void game_update()
 
     g_game_vars.timer++;
 
+    sprite_object_update_all();
     jokers_update_loop();
 
     state_machine_update();
@@ -2148,7 +2145,6 @@ static inline void played_cards_update_loop(void)
         }
 
         played[played_idx]->sprite_object->tscale = FIX_ONE;
-        card_object_update(played[played_idx]);
     }
 }
 
@@ -2263,12 +2259,11 @@ static inline void game_playing_discarded_cards_loop(void)
             discarded_card_object->sprite_object->x = int2fx(240);
             discarded_card_object->sprite_object->y = int2fx(80);
 
-            card_object_update(discarded_card_object);
+            // Update immediately to avoid flickering sprites at position (0,0)
+            sprite_object_update(discarded_card_object->sprite_object);
         }
         else
         {
-            card_object_update(discarded_card_object);
-
             if (discarded_card_object->sprite_object->y >= discarded_card_object->sprite_object->ty)
             {
                 deck_push(discarded_card_object->card); // Put the card back into the deck
@@ -2448,7 +2443,6 @@ static inline void cards_in_hand_update_loop(void)
 
             hand[i]->sprite_object->tx = hand_x;
             hand[i]->sprite_object->ty = hand_y;
-            card_object_update(hand[i]);
         }
     }
 }

--- a/source/game/main_menu.c
+++ b/source/game/main_menu.c
@@ -108,7 +108,9 @@ void game_main_menu_on_init(void)
     main_menu_ace->sprite_object->sprite->obj->attr0 |= ATTR0_AFF_DBL;
     main_menu_ace->sprite_object->tscale = float2fx(0.8f);
     sprite_object_position(main_menu_ace->sprite_object, MAIN_MENU_ACE_T_X, MAIN_MENU_ACE_T_Y);
-    card_object_update(main_menu_ace);
+
+    // Keep this update so there is no flicker on the first frame of the menu
+    sprite_object_update(main_menu_ace->sprite_object);
 
     // Select last highlighted button, Play button by default.
     // e.g. if we return from the options menu, we want the Options button to be highlighted.
@@ -122,7 +124,6 @@ void game_main_menu_on_init(void)
 void game_main_menu_on_update(void)
 {
     main_menu_ace->sprite_object->trotation = lu_sin((g_game_vars.timer << 8) / 2) / 3;
-    card_object_update(main_menu_ace);
 
     selection_grid_process_input(&main_menu_selection_grid);
 }

--- a/source/game/main_menu.c
+++ b/source/game/main_menu.c
@@ -109,9 +109,6 @@ void game_main_menu_on_init(void)
     main_menu_ace->sprite_object->tscale = float2fx(0.8f);
     sprite_object_position(main_menu_ace->sprite_object, MAIN_MENU_ACE_T_X, MAIN_MENU_ACE_T_Y);
 
-    // Keep this update so there is no flicker on the first frame of the menu
-    sprite_object_update(main_menu_ace->sprite_object);
-
     // Select last highlighted button, Play button by default.
     // e.g. if we return from the options menu, we want the Options button to be highlighted.
     Selection sel_init = {last_highlighted_button, 0};

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -589,9 +589,6 @@ void game_run_setup_on_init(void)
         RUN_SETUP_DECK_SPRITE_T_Y
     );
 
-    // Keep this update so there is no flicker on the first frame of the menu
-    sprite_object_update(run_setup_deck->sprite_object);
-
     /* Uncomment these lines when we figure out how to properly restore a game save
     is_saved_game_valid = is_game_data_valid();
     if (is_saved_game_valid)

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -589,7 +589,8 @@ void game_run_setup_on_init(void)
         RUN_SETUP_DECK_SPRITE_T_Y
     );
 
-    card_object_update(run_setup_deck);
+    // Keep this update so there is no flicker on the first frame of the menu
+    sprite_object_update(run_setup_deck->sprite_object);
 
     /* Uncomment these lines when we figure out how to properly restore a game save
     is_saved_game_valid = is_game_data_valid();

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -990,21 +990,6 @@ void game_shop_on_update(void)
 {
     timer++;
 
-    List* shop_jokers_list = &s_shop_jokers_list;
-
-    if (!list_is_empty(shop_jokers_list))
-    {
-        ListItr itr = list_itr_create(shop_jokers_list);
-        JokerObject* joker_object;
-        while ((joker_object = list_itr_next(&itr)))
-        {
-            if (joker_object != NULL)
-            {
-                joker_object_update(joker_object);
-            }
-        }
-    }
-
     if (timer % 20 == 0)
     {
         game_shop_lights_anim_frame();

--- a/source/joker.c
+++ b/source/joker.c
@@ -255,11 +255,6 @@ void joker_object_destroy(JokerObject** joker_object)
     *joker_object = NULL;
 }
 
-void joker_object_update(JokerObject* joker_object)
-{
-    sprite_object_update(joker_object->sprite_object);
-}
-
 void joker_object_shake(JokerObject* joker_object, mm_word sound_id)
 {
     sprite_object_shake(joker_object->sprite_object, sound_id);

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -301,6 +301,17 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
     sprite_position(sprite_object->sprite, fx2int(sprite_object->x), fx2int(sprite_object->y));
 }
 
+IWRAM_CODE void sprite_object_update_all(void)
+{
+    SpriteObject* sprite_object = NULL;
+    for (int i = 0; i < MAX_SPRITE_OBJECTS; i++)
+    {
+        sprite_object = POOL_AT(SpriteObject, i);
+        if (POOL_VALID_AT(SpriteObject, i) && sprite_object != NULL)
+            sprite_object_update(sprite_object);
+    }
+}
+
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 {
     if (sprite_object == NULL)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -310,12 +310,17 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
 
 IWRAM_CODE void sprite_object_update_all(void)
 {
-    SpriteObject* sprite_object = NULL;
-    ListItr itr = list_itr_create(&sprite_objects_list);
-    while ((sprite_object = list_itr_next(&itr)))
+    int nb_sprites = list_get_len(&sprite_objects_list);
+    for (u32 i = 0; i < nb_sprites; i++)
     {
-        sprite_object_update(sprite_object);
+        sprite_object_update(list_get_at_idx(&sprite_objects_list, i));
     }
+    //SpriteObject* sprite_object = NULL;
+    //ListItr itr = list_itr_create(&sprite_objects_list);
+    //while ((sprite_object = list_itr_next(&itr)))
+    //{
+    //    sprite_object_update(sprite_object);
+    //}
 }
 
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -308,19 +308,14 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
     sprite_position(sprite_object->sprite, fx2int(sprite_object->x), fx2int(sprite_object->y));
 }
 
-IWRAM_CODE void sprite_object_update_all(void)
+void sprite_object_update_all(void)
 {
-    int nb_sprites = list_get_len(&sprite_objects_list);
-    for (u32 i = 0; i < nb_sprites; i++)
+    SpriteObject* sprite_object = NULL;
+    ListItr itr = list_itr_create(&sprite_objects_list);
+    while ((sprite_object = list_itr_next(&itr)))
     {
-        sprite_object_update(list_get_at_idx(&sprite_objects_list, i));
+        sprite_object_update(sprite_object);
     }
-    //SpriteObject* sprite_object = NULL;
-    //ListItr itr = list_itr_create(&sprite_objects_list);
-    //while ((sprite_object = list_itr_next(&itr)))
-    //{
-    //    sprite_object_update(sprite_object);
-    //}
 }
 
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -28,6 +28,8 @@ OBJ_AFFINE* obj_aff_buffer = (OBJ_AFFINE*)obj_buffer;
 static Sprite* free_sprites[MAX_SPRITES] = {NULL};
 static bool free_affines[MAX_AFFINES] = {false};
 
+static List sprite_objects_list = LIST_DEFAULT;
+
 // Sprite methods
 Sprite* sprite_new(u16 a0, u16 a1, u32 tid, u32 pb, int sprite_index)
 {
@@ -174,6 +176,8 @@ SpriteObject* sprite_object_new()
     sprite_object_reset_transform(sprite_object);
     sprite_object->focused = false;
 
+    list_push_back(&sprite_objects_list, sprite_object);
+
     return sprite_object;
 }
 
@@ -181,6 +185,9 @@ void sprite_object_destroy(SpriteObject** sprite_object)
 {
     if (*sprite_object == NULL)
         return;
+
+    list_remove_data(&sprite_objects_list, *sprite_object);
+
     sprite_destroy(&(*sprite_object)->sprite);
     POOL_FREE(SpriteObject, *sprite_object);
     *sprite_object = NULL;
@@ -304,11 +311,10 @@ IWRAM_CODE void sprite_object_update(SpriteObject* sprite_object)
 IWRAM_CODE void sprite_object_update_all(void)
 {
     SpriteObject* sprite_object = NULL;
-    for (int i = 0; i < MAX_SPRITE_OBJECTS; i++)
+    ListItr itr = list_itr_create(&sprite_objects_list);
+    while ((sprite_object = list_itr_next(&itr)))
     {
-        sprite_object = POOL_AT(SpriteObject, i);
-        if (POOL_VALID_AT(SpriteObject, i) && sprite_object != NULL)
-            sprite_object_update(sprite_object);
+        sprite_object_update(sprite_object);
     }
 }
 


### PR DESCRIPTION
Closes #535

I did keep some updates to certain sprites, these are done to avoid flickering by showing a newly created sprite at position (0,0) for a single frame before it gets updated.

Here is the game running without any visible issue:

https://github.com/user-attachments/assets/01efef09-a1a0-40f6-b637-8cdab522ad97

Edit: I did notice a slight flicker of the cards when playing them, I moved some updates around and it turns out I don't need the few calls to `sprite_object_update` I kept after all ^^