### PR TITLE
Add logging macros that include the function name

### DIFF
--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -17,7 +17,7 @@
  * mgba -l 14 game.rom # INFO, WARN, and ERROR
  * ```
  *
- * @note You have to fight with other logs in mgba and DEBUG can get messy.
+ * @note You have to fight with other logs in mgba and INFO can get messy.
  *
  * @note FATAL does kill the game. Use with care.
  */

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -63,7 +63,6 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...);
  * @param ... variadic arguments
  *
  * @note for all logs, it's cutoff at the hard mgba limit of 0x100
- * @note The function name may be dropped if the resulting string exceeds this limit.
  */
 void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...);
 

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -101,18 +101,18 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
 #endif
 // clang-format on
 
-#define CHECK_NULL_ARG_VOID(param)\
-    if ((param) == NULL)\
-    {\
+#define CHECK_NULL_ARG_VOID(param)                                 \
+    if ((param) == NULL)                                           \
+    {                                                              \
         MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-        return;\
+        return;                                                    \
     }
 
-#define CHECK_NULL_ARG_RET(param, ret_val)\
-    if ((param) == NULL)\
-    {\
+#define CHECK_NULL_ARG_RET(param, ret_val)                         \
+    if ((param) == NULL)                                           \
+    {                                                              \
         MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-        return ret_val;\
+        return ret_val;                                            \
     }
 
 #endif

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -56,17 +56,34 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...);
 
 // clang-format off
 #ifdef MGBA_LOGGING
+
 #define MGBA_FATAL(...) mgba_printf(MGBA_LOG_FATAL, __VA_ARGS__)
 #define MGBA_ERROR(...) mgba_printf(MGBA_LOG_ERROR, __VA_ARGS__)
 #define MGBA_WARN(...)  mgba_printf(MGBA_LOG_WARN,  __VA_ARGS__)
 #define MGBA_INFO(...)  mgba_printf(MGBA_LOG_INFO,  __VA_ARGS__)
 #define MGBA_DEBUG(...) mgba_printf(MGBA_LOG_DEBUG, __VA_ARGS__)
+
+#define MGBA_FUNC_LOG(level, ...) mgba_func_printf(level, __func__, __VA_ARGS__)
+
+#define MGBA_FUNC_FATAL(...) MGBA_FUNC_LOG(MGBA_LOG_FATAL, __VA_ARGS__)
+#define MGBA_FUNC_ERROR(...) MGBA_FUNC_LOG(MGBA_LOG_ERROR, __VA_ARGS__)
+#define MGBA_FUNC_WARN(...)  MGBA_FUNC_LOG(MGBA_LOG_WARN,  __VA_ARGS__)
+#define MGBA_FUNC_INFO(...)  MGBA_FUNC_LOG(MGBA_LOG_INFO,  __VA_ARGS__)
+#define MGBA_FUNC_DEBUG(...) MGBA_FUNC_LOG(MGBA_LOG_DEBUG, __VA_ARGS__)
+
 #else
+          
 #define MGBA_FATAL(...) ((void)0)
 #define MGBA_ERROR(...) ((void)0)
 #define MGBA_WARN(...) ((void)0)
 #define MGBA_INFO(...) ((void)0)
 #define MGBA_DEBUG(...) ((void)0)
+
+#define MGBA_FUNC_FATAL(...) ((void)0)
+#define MGBA_FUNC_ERROR(...) ((void)0)
+#define MGBA_FUNC_WARN(...) ((void)0)
+#define MGBA_FUNC_INFO(...) ((void)0)
+#define MGBA_FUNC_DEBUG(...) ((void)0)
 #endif
 // clang-format on
 

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -107,12 +107,15 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
  * This version is for a void function, while @ref CHECK_NULL_ARG_RET is for one with
  * a return value.
  */
-#define CHECK_NULL_ARG_VOID(param)                                 \
-    if ((param) == NULL)                                           \
-    {                                                              \
-        MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-        return;                                                    \
-    }
+#define CHECK_NULL_ARG_VOID(param)                                      \
+    do                                                                  \
+    {                                                                   \
+        if ((param) == NULL)                                            \
+        {                                                               \
+            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param);  \
+            return;                                                     \
+        }                                                               \
+    } while (0)
 
 /**
  * @brief Checks if @p param is NULL and prints error message and returns in case it is.
@@ -121,11 +124,14 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
  * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
  * is for a void function.
  */
-#define CHECK_NULL_ARG_RET(param, ret_val)                         \
-    if ((param) == NULL)                                           \
-    {                                                              \
-        MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-        return ret_val;                                            \
-    }
+#define CHECK_NULL_ARG_RET(param, ret_val)                              \
+    do                                                                  \
+    {                                                                   \
+        if ((param) == NULL)                                            \
+        {                                                               \
+            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param);  \
+            return ret_val;                                             \
+        }                                                               \
+    } while (0)
 
 #endif

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -58,7 +58,7 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...);
  * @brief Print to mgba log with a format string and function name
  *
  * @param level
- * @param func_name Function name - prepended to the log string "<func_name>: <log_string>"
+ * @param func_name Function name - prepended to the log string "<func_name>(): <log_string>"
  * @param fmt Format string
  * @param ... variadic arguments
  *

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -102,37 +102,4 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
 #endif
 // clang-format on
 
-/**
- * @brief Checks if @p param is NULL and prints error message and returns in case it is.
- * Useful for checking arguments to a function.
- * This version is for a void function, while @ref CHECK_NULL_ARG_RET is for one with
- * a return value.
- */
-#define CHECK_NULL_ARG_VOID(param)                                     \
-    do                                                                 \
-    {                                                                  \
-        if ((param) == NULL)                                           \
-        {                                                              \
-            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-            return;                                                    \
-        }                                                              \
-    } while (0)
-
-/**
- * @brief Checks if @p param is NULL and prints error message and returns in case it is.
- * Useful for checking arguments to a function.
- * @param ret_val The value to return in case @p param is NULL.
- * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
- * is for a void function.
- */
-#define CHECK_NULL_ARG_RET(param, ret_val)                             \
-    do                                                                 \
-    {                                                                  \
-        if ((param) == NULL)                                           \
-        {                                                              \
-            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-            return ret_val;                                            \
-        }                                                              \
-    } while (0)
-
 #endif

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -101,6 +101,12 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
 #endif
 // clang-format on
 
+/**
+ * @brief Checks if @p param is NULL and prints error message and returns in case it is.
+ * Useful for checking arguments to a function.
+ * This version is for a void function, while @ref CHECK_NULL_ARG_RET is for one with
+ * a return value.
+ */
 #define CHECK_NULL_ARG_VOID(param)                                 \
     if ((param) == NULL)                                           \
     {                                                              \
@@ -108,6 +114,13 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
         return;                                                    \
     }
 
+/**
+ * @brief Checks if @p param is NULL and prints error message and returns in case it is.
+ * Useful for checking arguments to a function.
+ * @param ret_val The value to return in case @p param is NULL.
+ * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
+ * us for a void function.
+ */
 #define CHECK_NULL_ARG_RET(param, ret_val)                         \
     if ((param) == NULL)                                           \
     {                                                              \

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -54,6 +54,18 @@ bool mgba_logger_init(void);
  */
 void mgba_printf(MgbaLogLevel level, const char* fmt, ...);
 
+/**
+ * @brief Print to mgba log with a format string and function name
+ *
+ * @param level
+ * @param func_name Function name - prepended to the log string "<func_name>: <log_string>"
+ * @param fmt Format string
+ * @param ... variadic arguments
+ *
+ * @note for all logs, it's cutoff at the hard mgba limit of 0x100
+ */
+void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...);
+
 // clang-format off
 #ifdef MGBA_LOGGING
 

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -101,18 +101,18 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
 #endif
 // clang-format on
 
-#define CHECK_NULL_ARG_VOID(param) \
-    if ((param) == NULL) \
-    { \
+#define CHECK_NULL_ARG_VOID(param)\
+    if ((param) == NULL)\
+    {\
         MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-        return; \
+        return;\
     }
 
-#define CHECK_NULL_ARG_RET(param, ret_val) \
-    if ((param) == NULL) \
-    { \
+#define CHECK_NULL_ARG_RET(param, ret_val)\
+    if ((param) == NULL)\
+    {\
         MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
-        return ret_val; \
+        return ret_val;\
     }
 
 #endif

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -119,7 +119,7 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
  * Useful for checking arguments to a function.
  * @param ret_val The value to return in case @p param is NULL.
  * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
- * us for a void function.
+ * is for a void function.
  */
 #define CHECK_NULL_ARG_RET(param, ret_val)                         \
     if ((param) == NULL)                                           \

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -101,4 +101,18 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
 #endif
 // clang-format on
 
+#define CHECK_NULL_ARG_VOID(param) \
+    if ((param) == NULL) \
+    { \
+        MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
+        return; \
+    }
+
+#define CHECK_NULL_ARG_RET(param, ret_val) \
+    if ((param) == NULL) \
+    { \
+        MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
+        return ret_val; \
+    }
+
 #endif

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -63,6 +63,7 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...);
  * @param ... variadic arguments
  *
  * @note for all logs, it's cutoff at the hard mgba limit of 0x100
+ * @note The function name may be dropped if the resulting string exceeds this limit.
  */
 void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...);
 

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -108,14 +108,14 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
  * This version is for a void function, while @ref CHECK_NULL_ARG_RET is for one with
  * a return value.
  */
-#define CHECK_NULL_ARG_VOID(param)                                      \
-    do                                                                  \
-    {                                                                   \
-        if ((param) == NULL)                                            \
-        {                                                               \
-            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param);  \
-            return;                                                     \
-        }                                                               \
+#define CHECK_NULL_ARG_VOID(param)                                     \
+    do                                                                 \
+    {                                                                  \
+        if ((param) == NULL)                                           \
+        {                                                              \
+            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
+            return;                                                    \
+        }                                                              \
     } while (0)
 
 /**
@@ -125,14 +125,14 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
  * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
  * is for a void function.
  */
-#define CHECK_NULL_ARG_RET(param, ret_val)                              \
-    do                                                                  \
-    {                                                                   \
-        if ((param) == NULL)                                            \
-        {                                                               \
-            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param);  \
-            return ret_val;                                             \
-        }                                                               \
+#define CHECK_NULL_ARG_RET(param, ret_val)                             \
+    do                                                                 \
+    {                                                                  \
+        if ((param) == NULL)                                           \
+        {                                                              \
+            MGBA_FUNC_ERROR("Called with NULL '%s' argument", #param); \
+            return ret_val;                                            \
+        }                                                              \
     } while (0)
 
 #endif

--- a/include/mgba_logger.h
+++ b/include/mgba_logger.h
@@ -79,6 +79,8 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...);
 #define MGBA_INFO(...) ((void)0)
 #define MGBA_DEBUG(...) ((void)0)
 
+#define MGBA_FUNC_LOG(level, ...) ((void)0)
+
 #define MGBA_FUNC_FATAL(...) ((void)0)
 #define MGBA_FUNC_ERROR(...) ((void)0)
 #define MGBA_FUNC_WARN(...) ((void)0)

--- a/include/util.h
+++ b/include/util.h
@@ -73,14 +73,14 @@
  * This version is for a void function, while @ref GBAL_RETURN_ON_ERROR_VAL_RET is for one with
  * a return value.
  */
-#define GBAL_RETURN_IF_NULL_VOID(param)                      \
-    do                                                       \
-    {                                                        \
-        if ((param) == NULL)                                 \
-        {                                                    \
+#define GBAL_RETURN_IF_NULL_VOID(param)                       \
+    do                                                        \
+    {                                                         \
+        if ((param) == NULL)                                  \
+        {                                                     \
             LOG_ERROR("Unexpected value: %s = NULL", #param); \
-            return;                                          \
-        }                                                    \
+            return;                                           \
+        }                                                     \
     } while (0)
 
 /**
@@ -92,14 +92,14 @@
  * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */
-#define GBAL_RETURN_IF_NULL_RET(param, ret_val)              \
-    do                                                       \
-    {                                                        \
-        if ((param) == NULL)                                 \
-        {                                                    \
+#define GBAL_RETURN_IF_NULL_RET(param, ret_val)               \
+    do                                                        \
+    {                                                         \
+        if ((param) == NULL)                                  \
+        {                                                     \
             LOG_ERROR("Unexpected value: %s = NULL", #param); \
-            return (ret_val);                                \
-        }                                                    \
+            return (ret_val);                                 \
+        }                                                     \
     } while (0)
 
 /**

--- a/include/util.h
+++ b/include/util.h
@@ -69,7 +69,7 @@
 /**
  * @brief Checks if @p param is NULL and prints error message and returns in case it is.
  * Useful for checking arguments to a function or general error values in code flow.
- * 
+ *
  * This version is for a void function, while @ref GBAL_RETURN_ON_ERROR_VAL_RET is for one with
  * a return value.
  */
@@ -88,7 +88,7 @@
  * and prints error message and returns in case it is.
  * Useful for checking arguments to a function or error values.
  * @param ret_val The value to return in case @p param is equal to @p err_val.
- * 
+ *
  * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */

--- a/include/util.h
+++ b/include/util.h
@@ -68,51 +68,39 @@
 
 /**
  * @brief Checks if @p param is NULL and prints error message and returns in case it is.
- * Useful for checking arguments to a function or general error values in code flow.
+ * Useful for checking arguments to a function or errors during control flow.
  *
  * This version is for a void function, while @ref GBAL_RETURN_ON_ERROR_VAL_RET is for one with
  * a return value.
  */
-#define GBAL_RETURN_ON_ERROR_VAL_VOID(param, err_val)                      \
-    do                                                                     \
-    {                                                                      \
-        if ((param) == (err_val))                                          \
-        {                                                                  \
-            LOG_ERROR("Unexpected error value %s = %s", #param, #err_val); \
-            return;                                                        \
-        }                                                                  \
+#define GBAL_RETURN_IF_NULL_VOID(param)                      \
+    do                                                       \
+    {                                                        \
+        if ((param) == NULL)                                 \
+        {                                                    \
+            LOG_ERROR("Unexpected value: %s = NULL", #param); \
+            return;                                          \
+        }                                                    \
     } while (0)
 
 /**
- * @brief Checks if @p param is equal to @p err_val
+ * @brief Checks if @p param is equal to NULL
  * and prints error message and returns in case it is.
- * Useful for checking arguments to a function or error values.
- * @param ret_val The value to return in case @p param is equal to @p err_val.
+ * Useful for checking arguments to a function or errors during control flow.
+ * @param ret_val The value to return in case @p param is equal to NULL.
  *
  * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */
-#define GBAL_RETURN_ON_ERROR_VAL_RET(param, err_val, ret_val)              \
-    do                                                                     \
-    {                                                                      \
-        if ((param) == (err_val))                                          \
-        {                                                                  \
-            LOG_ERROR("Unexpected error value %s = %s", #param, #err_val); \
-            return (ret_val);                                              \
-        }                                                                  \
+#define GBAL_RETURN_IF_NULL_RET(param, ret_val)              \
+    do                                                       \
+    {                                                        \
+        if ((param) == NULL)                                 \
+        {                                                    \
+            LOG_ERROR("Unexpected value: %s = NULL", #param); \
+            return (ret_val);                                \
+        }                                                    \
     } while (0)
-
-/**
- * @brief Returns if @p param is NULL.
- * Like @ref GBAL_RETURN_ON_ERROR_VAL_VOID but specifically for NULL
- */
-#define GBAL_RETURN_IF_NULL_VOID(param) GBAL_RETURN_ON_ERROR_VAL_VOID(param, NULL);
-
-/**
- * @brief Returns @p ret_val if @p param is NULL.
- * Like @ref GBAL_RETURN_ON_ERROR_VAL_RET but specifically for NULL
- */
-#define GBAL_RETURN_IF_NULL_RET(param, ret_val) GBAL_RETURN_ON_ERROR_VAL_RET(param, NULL, ret_val);
 
 /**
  * @brief Avoid overflow when adding two u32 integers

--- a/include/util.h
+++ b/include/util.h
@@ -78,7 +78,7 @@
     {                                                         \
         if ((param) == NULL)                                  \
         {                                                     \
-            LOG_ERROR("Unexpected value: %s = NULL", #param); \
+            LOG_ERROR("Unexpected value: %s == NULL", #param); \
             return;                                           \
         }                                                     \
     } while (0)

--- a/include/util.h
+++ b/include/util.h
@@ -73,14 +73,14 @@
  * This version is for a void function, while @ref GBAL_RETURN_ON_ERROR_VAL_RET is for one with
  * a return value.
  */
-#define GBAL_RETURN_IF_NULL_VOID(param)                       \
-    do                                                        \
-    {                                                         \
-        if ((param) == NULL)                                  \
-        {                                                     \
+#define GBAL_RETURN_IF_NULL_VOID(param)                        \
+    do                                                         \
+    {                                                          \
+        if ((param) == NULL)                                   \
+        {                                                      \
             LOG_ERROR("Unexpected value: %s == NULL", #param); \
-            return;                                           \
-        }                                                     \
+            return;                                            \
+        }                                                      \
     } while (0)
 
 /**

--- a/include/util.h
+++ b/include/util.h
@@ -8,6 +8,9 @@
 #define UTIL_H
 
 #include <stdint.h>
+#ifdef MGBA_LOGGING
+#include "mgba_logger.h"
+#endif
 
 /**
  * @def GBAL_UNUSED
@@ -55,6 +58,46 @@
 // The suffix replaces everything past the third digit, e.g. "999K" -> "1M"
 // so it needs at least this number of chars to be able to display any suffixed number
 #define SUFFIXED_NUM_MIN_REQ_CHARS 4
+
+#ifdef MGBA_LOGGING
+#define LOG_ERROR(...) MGBA_FUNC_ERROR(__VA_ARGS__)
+#else
+#define LOG_ERROR(...) ((void)(0))
+#endif
+
+/**
+ * @brief Checks if @p param is NULL and prints error message and returns in case it is.
+ * Useful for checking arguments to a function.
+ * This version is for a void function, while @ref CHECK_NULL_ARG_RET is for one with
+ * a return value.
+ */
+#define CHECK_NULL_ARG_VOID(param)                                     \
+    do                                                                 \
+    {                                                                  \
+        if ((param) == NULL)                                           \
+        {                                                              \
+            LOG_ERROR("Called with NULL '%s' argument", #param);       \
+            return;                                                    \
+        }                                                              \
+    } while (0)
+
+/**
+ * @brief Checks if @p param is NULL and prints error message and returns in case it is.
+ * Useful for checking arguments to a function.
+ * @param ret_val The value to return in case @p param is NULL.
+ * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
+ * is for a void function.
+ */
+#define CHECK_NULL_ARG_RET(param, ret_val)                             \
+    do                                                                 \
+    {                                                                  \
+        if ((param) == NULL)                                           \
+        {                                                              \
+            LOG_ERROR("Called with NULL '%s' argument", #param);       \
+            return (ret_val);                                          \
+        }                                                              \
+    } while (0)
+
 
 /**
  * @brief Avoid overflow when adding two u32 integers
@@ -198,5 +241,7 @@ uint32_t base36_to_u32(const char b36_str[]);
  * @sa base36_to_u32
  */
 void u32_to_base36(uint32_t n, char b36_str[]);
+
+
 
 #endif // UTIL_H

--- a/include/util.h
+++ b/include/util.h
@@ -92,14 +92,14 @@
  * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */
-#define GBAL_RETURN_IF_NULL_RET(param, ret_val)               \
-    do                                                        \
-    {                                                         \
-        if ((param) == NULL)                                  \
-        {                                                     \
-            LOG_ERROR("Unexpected value: %s = NULL", #param); \
-            return (ret_val);                                 \
-        }                                                     \
+#define GBAL_RETURN_IF_NULL_RET(param, ret_val)                \
+    do                                                         \
+    {                                                          \
+        if ((param) == NULL)                                   \
+        {                                                      \
+            LOG_ERROR("Unexpected value: %s == NULL", #param); \
+            return (ret_val);                                  \
+        }                                                      \
     } while (0)
 
 /**

--- a/include/util.h
+++ b/include/util.h
@@ -68,36 +68,51 @@
 
 /**
  * @brief Checks if @p param is NULL and prints error message and returns in case it is.
- * Useful for checking arguments to a function.
- * This version is for a void function, while @ref GBAL_CHECK_NULL_ARG_RET is for one with
+ * Useful for checking arguments to a function or general error values in code flow.
+ * 
+ * This version is for a void function, while @ref GBAL_RETURN_ON_ERROR_VAL_RET is for one with
  * a return value.
  */
-#define GBAL_CHECK_NULL_ARG_VOID(param)                          \
-    do                                                           \
-    {                                                            \
-        if ((param) == NULL)                                     \
-        {                                                        \
-            LOG_ERROR("Called with NULL '%s' argument", #param); \
-            return;                                              \
-        }                                                        \
+#define GBAL_RETURN_ON_ERROR_VAL_VOID(param, err_val)                      \
+    do                                                                     \
+    {                                                                      \
+        if ((param) == (err_val))                                          \
+        {                                                                  \
+            LOG_ERROR("Unexpected error value %s = %s", #param, #err_val); \
+            return;                                                        \
+        }                                                                  \
     } while (0)
 
 /**
- * @brief Checks if @p param is NULL and prints error message and returns in case it is.
- * Useful for checking arguments to a function.
- * @param ret_val The value to return in case @p param is NULL.
- * This version is for a function that returns a value while @ref GBAL_CHECK_NULL_ARG_VOID
+ * @brief Checks if @p param is equal to @p err_val
+ * and prints error message and returns in case it is.
+ * Useful for checking arguments to a function or error values.
+ * @param ret_val The value to return in case @p param is equal to @p err_val.
+ * 
+ * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */
-#define GBAL_CHECK_NULL_ARG_RET(param, ret_val)                  \
-    do                                                           \
-    {                                                            \
-        if ((param) == NULL)                                     \
-        {                                                        \
-            LOG_ERROR("Called with NULL '%s' argument", #param); \
-            return (ret_val);                                    \
-        }                                                        \
+#define GBAL_RETURN_ON_ERROR_VAL_RET(param, err_val, ret_val)              \
+    do                                                                     \
+    {                                                                      \
+        if ((param) == (err_val))                                          \
+        {                                                                  \
+            LOG_ERROR("Unexpected error value %s = %s", #param, #err_val); \
+            return (ret_val);                                              \
+        }                                                                  \
     } while (0)
+
+/**
+ * @brief Returns if @p param is NULL.
+ * Like @ref GBAL_RETURN_ON_ERROR_VAL_VOID but specifically for NULL
+ */
+#define GBAL_RETURN_IF_NULL_VOID(param) GBAL_RETURN_ON_ERROR_VAL_VOID(param, NULL);
+
+/**
+ * @brief Returns @p ret_val if @p param is NULL.
+ * Like @ref GBAL_RETURN_ON_ERROR_VAL_RET but specifically for NULL
+ */
+#define GBAL_RETURN_IF_NULL_RET(param, ret_val) GBAL_RETURN_ON_ERROR_VAL_RET(param, NULL, ret_val);
 
 /**
  * @brief Avoid overflow when adding two u32 integers

--- a/include/util.h
+++ b/include/util.h
@@ -62,42 +62,42 @@
 #ifdef MGBA_LOGGING
 #define LOG_ERROR(...) MGBA_FUNC_ERROR(__VA_ARGS__)
 #else
+// TODO: Add a define to conditionally compile print error to console and add it to the tests?
 #define LOG_ERROR(...) ((void)(0))
 #endif
 
 /**
  * @brief Checks if @p param is NULL and prints error message and returns in case it is.
  * Useful for checking arguments to a function.
- * This version is for a void function, while @ref CHECK_NULL_ARG_RET is for one with
+ * This version is for a void function, while @ref GBAL_CHECK_NULL_ARG_RET is for one with
  * a return value.
  */
-#define CHECK_NULL_ARG_VOID(param)                                     \
-    do                                                                 \
-    {                                                                  \
-        if ((param) == NULL)                                           \
-        {                                                              \
-            LOG_ERROR("Called with NULL '%s' argument", #param);       \
-            return;                                                    \
-        }                                                              \
+#define GBAL_CHECK_NULL_ARG_VOID(param)                          \
+    do                                                           \
+    {                                                            \
+        if ((param) == NULL)                                     \
+        {                                                        \
+            LOG_ERROR("Called with NULL '%s' argument", #param); \
+            return;                                              \
+        }                                                        \
     } while (0)
 
 /**
  * @brief Checks if @p param is NULL and prints error message and returns in case it is.
  * Useful for checking arguments to a function.
  * @param ret_val The value to return in case @p param is NULL.
- * This version is for a function that returns a value while @ref CHECK_NULL_ARG_VOID
+ * This version is for a function that returns a value while @ref GBAL_CHECK_NULL_ARG_VOID
  * is for a void function.
  */
-#define CHECK_NULL_ARG_RET(param, ret_val)                             \
-    do                                                                 \
-    {                                                                  \
-        if ((param) == NULL)                                           \
-        {                                                              \
-            LOG_ERROR("Called with NULL '%s' argument", #param);       \
-            return (ret_val);                                          \
-        }                                                              \
+#define GBAL_CHECK_NULL_ARG_RET(param, ret_val)                  \
+    do                                                           \
+    {                                                            \
+        if ((param) == NULL)                                     \
+        {                                                        \
+            LOG_ERROR("Called with NULL '%s' argument", #param); \
+            return (ret_val);                                    \
+        }                                                        \
     } while (0)
-
 
 /**
  * @brief Avoid overflow when adding two u32 integers
@@ -241,7 +241,5 @@ uint32_t base36_to_u32(const char b36_str[]);
  * @sa base36_to_u32
  */
 void u32_to_base36(uint32_t n, char b36_str[]);
-
-
 
 #endif // UTIL_H

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -54,28 +54,13 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
     }
 
     char printed_str_buff[MGBA_LOG_BUFFER_SIZE];
-    int chars_used =
-        snprintf(printed_str_buff, sizeof(printed_str_buff), "%s(): %s", func_name, fmt);
 
-
-    if ((size_t)chars_used < sizeof(printed_str_buff))
-    {
-        va_list args;
-        va_start(args, fmt);
-        mgba_vprintf(level, printed_str_buff, args);
-        va_end(args);
-    }
-    else
-    {
-        // The buffer is not large enough, format has been truncated, expand the format
-        // and truncate the string, keeping the function name.
-        va_list args;
-        va_start(args, fmt);
-        vsnprintf(printed_str_buff, sizeof(printed_str_buff), fmt, args);
-        va_end(args); 
-
-        mgba_printf("%s(): %s", func_name, printed_str_buff);
-    }
+    // Expand the format first so the full string is truncated in case it's too long
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(printed_str_buff, sizeof(printed_str_buff), fmt, args);
+    va_end(args); 
+    mgba_printf(level, "%s(): %s", func_name, printed_str_buff);
 }
 
 #else

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -47,7 +47,7 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
 void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...)
 { 
     char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
-    snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s: %s", func_name, fmt);
+    snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
 
     va_list args;
     va_start(args, fmt);

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -30,7 +30,7 @@ static void mgba_vprintf(MgbaLogLevel level, const char* fmt, va_list args)
 {
     if (!mgba_logger_available || fmt == NULL)
         return;
-        
+
     vsnprintf(MGBA_REG_DEBUG_STRING, MGBA_LOG_BUFFER_SIZE, fmt, args);
 
     *MGBA_REG_DEBUG_FLAGS = ((uint16_t)level & 0x7) | MGBA_LOG_SEND;
@@ -45,7 +45,7 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
 }
 
 void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...)
-{ 
+{
     char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
     snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
 

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -54,7 +54,9 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
     }
 
     char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
-    int chars_used = snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
+    int chars_used = snprintf(
+        func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt
+    );
     
     char* printed_str = func_name_fmt_buff;
     

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -16,6 +16,7 @@ static const u32 MGBA_ENABLE_MAGIC = 0xC0DE;
 static const u32 MGBA_ENABLE_OK = 0x1DEA;
 static const u32 MGBA_LOG_SEND = 0x100;
 static const u32 MGBA_LOG_BUFFER_SIZE = 0x100;
+static const u16 MGBA_LOG_LEVEL_MASK = 0x7;
 
 static bool mgba_logger_available = false;
 
@@ -33,7 +34,7 @@ static void mgba_vprintf(MgbaLogLevel level, const char* fmt, va_list args)
 
     vsnprintf(MGBA_REG_DEBUG_STRING, MGBA_LOG_BUFFER_SIZE, fmt, args);
 
-    *MGBA_REG_DEBUG_FLAGS = ((uint16_t)level & 0x7) | MGBA_LOG_SEND;
+    *MGBA_REG_DEBUG_FLAGS = ((uint16_t)level & MGBA_LOG_LEVEL_MASK) | MGBA_LOG_SEND;
 }
 
 void mgba_printf(MgbaLogLevel level, const char* fmt, ...)

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -47,12 +47,26 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
 
 void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...)
 {
+    if (func_name == NULL || fmt == NULL)
+    {
+        // The one place where we can't log the error.
+        return;
+    }
+
     char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
-    snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
+    int chars_used = snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
+    
+    char* printed_str = func_name_fmt_buff;
+    
+    if ((size_t)chars_used > sizeof(func_name_fmt_buff) - 1)
+    {
+        // The buffer is not large enough, format has been truncated, drop the function name
+        printed_str = fmt;
+    }
 
     va_list args;
     va_start(args, fmt);
-    mgba_vprintf(level, func_name_fmt_buff, args);
+    mgba_vprintf(level, printed_str, args);
     va_end(args);
 }
 

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -53,22 +53,29 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
         return;
     }
 
-    char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
+    char printed_str_buff[MGBA_LOG_BUFFER_SIZE];
     int chars_used =
-        snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
+        snprintf(printed_str_buff, sizeof(printed_str_buff), "%s(): %s", func_name, fmt);
 
-    char* printed_str = func_name_fmt_buff;
 
-    if ((size_t)chars_used > sizeof(func_name_fmt_buff) - 1)
+    if ((size_t)chars_used < sizeof(printed_str_buff))
     {
-        // The buffer is not large enough, format has been truncated, drop the function name
-        printed_str = fmt;
+        va_list args;
+        va_start(args, fmt);
+        mgba_vprintf(level, printed_str_buff, args);
+        va_end(args);
     }
+    else
+    {
+        // The buffer is not large enough, format has been truncated, expand the format
+        // and truncate the string, keeping the function name.
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(printed_str_buff, sizeof(printed_str_buff), fmt, args);
+        va_end(args); 
 
-    va_list args;
-    va_start(args, fmt);
-    mgba_vprintf(level, printed_str, args);
-    va_end(args);
+        mgba_printf("%s(): %s", func_name, printed_str_buff);
+    }
 }
 
 #else

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -47,7 +47,7 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
 
 void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...)
 {
-    if (func_name == NULL || fmt == NULL)
+    if (!mgba_logger_available || func_name == NULL || fmt == NULL)
     {
         // The one place where we can't log the error.
         return;

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -26,18 +26,35 @@ bool mgba_logger_init(void)
     return mgba_logger_available;
 }
 
-void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
+static void mgba_vprintf(MgbaLogLevel level, const char* fmt, va_list args)
 {
     if (!mgba_logger_available || fmt == NULL)
         return;
-
-    va_list args;
-    va_start(args, fmt);
+        
     vsnprintf(MGBA_REG_DEBUG_STRING, MGBA_LOG_BUFFER_SIZE, fmt, args);
-    va_end(args);
 
     *MGBA_REG_DEBUG_FLAGS = ((uint16_t)level & 0x7) | MGBA_LOG_SEND;
 }
+
+void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    mgba_vprintf(level, fmt, args);
+    va_end(args);
+}
+
+void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...)
+{ 
+    char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
+    snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s: %s", func_name, fmt);
+
+    va_list args;
+    va_start(args, fmt);
+    mgba_vprintf(level, func_name_fmt_buff, args);
+    va_end(args);
+}
+
 #else
 
 // Noop stubs
@@ -50,4 +67,7 @@ void mgba_printf(MgbaLogLevel level, const char* fmt, ...)
 {
 }
 
+void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt, ...)
+{
+}
 #endif

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -54,12 +54,11 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
     }
 
     char func_name_fmt_buff[MGBA_LOG_BUFFER_SIZE];
-    int chars_used = snprintf(
-        func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt
-    );
-    
+    int chars_used =
+        snprintf(func_name_fmt_buff, sizeof(func_name_fmt_buff), "%s(): %s", func_name, fmt);
+
     char* printed_str = func_name_fmt_buff;
-    
+
     if ((size_t)chars_used > sizeof(func_name_fmt_buff) - 1)
     {
         // The buffer is not large enough, format has been truncated, drop the function name

--- a/source/mgba_logger.c
+++ b/source/mgba_logger.c
@@ -59,7 +59,7 @@ void mgba_func_printf(MgbaLogLevel level, const char* func_name, const char* fmt
     va_list args;
     va_start(args, fmt);
     vsnprintf(printed_str_buff, sizeof(printed_str_buff), fmt, args);
-    va_end(args); 
+    va_end(args);
     mgba_printf(level, "%s(): %s", func_name, printed_str_buff);
 }
 


### PR DESCRIPTION
Closes #555 

I opted to not replace the existing log functions and macros to allow logging without the function name.
I extracted `mgba_vprintf` that accepts a `va_list` from `mgba_printf`, that way I can call it from my other function.
I am wondering whether to change the names of the log macros to from `MGBA_ERROR`, `MGBA_WARN`, etc, to `MGBA_LOG_ERROR`, `MGBA_LOG_WARN` to make it a little clearer that they write to a log.
That way I could also change my added macros `MGBA_FUNC_ERROR`, `MGBA_FUNC_WARN` to `MGBA_FUNC_LOG_ERROR`, `MGBA_FUNC_LOG_WARN` which I think would make them clearer.