### PR TITLE
Implement new `sprite_object_position` function

### DIFF
--- a/include/sprite.h
+++ b/include/sprite.h
@@ -365,4 +365,21 @@ INLINE void sprite_position(Sprite* sprite, int x, int y)
     obj_set_pos(sprite->obj, x, y);
 }
 
+/**
+ * @brief Set sprite_object position. Inlined for efficiency
+ *
+ * @param sprite_object poitner to a SpriteObject to adjust the position of. A **NULL** check is not
+ *        performed, though the value cannot be **NULL**.
+ *
+ * @param x horizontal position in pixels
+ * @param y vertical position in pixels
+ */
+INLINE void sprite_object_position(SpriteObject* sprite_object, int x, int y)
+{
+    sprite_object->x = int2fx(x);
+    sprite_object->y = int2fx(y);
+    sprite_object->tx = int2fx(x);
+    sprite_object->ty = int2fx(y);
+}
+
 #endif // SPRITE_H

--- a/source/game/main_menu.c
+++ b/source/game/main_menu.c
@@ -106,11 +106,8 @@ void game_main_menu_on_init(void)
     main_menu_ace = card_object_new(card_new(SPADES, ACE));
     card_object_set_sprite(main_menu_ace, 0);
     main_menu_ace->sprite_object->sprite->obj->attr0 |= ATTR0_AFF_DBL;
-    main_menu_ace->sprite_object->tx = int2fx(MAIN_MENU_ACE_T_X);
-    main_menu_ace->sprite_object->x = main_menu_ace->sprite_object->tx;
-    main_menu_ace->sprite_object->ty = int2fx(MAIN_MENU_ACE_T_Y);
-    main_menu_ace->sprite_object->y = main_menu_ace->sprite_object->ty;
     main_menu_ace->sprite_object->tscale = float2fx(0.8f);
+    sprite_object_position(main_menu_ace->sprite_object, MAIN_MENU_ACE_T_X, MAIN_MENU_ACE_T_Y);
     card_object_update(main_menu_ace);
 
     // Select last highlighted button, Play button by default.

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -583,12 +583,11 @@ void game_run_setup_on_init(void)
     // both cards do not exist at the same time, one is destroyed before the other is created.
     card_object_set_sprite_face_down(run_setup_deck, g_game_vars.deck, 0);
 
-    run_setup_deck->sprite_object->tx = int2fx(RUN_SETUP_DECK_SPRITE_T_X);
-    run_setup_deck->sprite_object->ty = int2fx(RUN_SETUP_DECK_SPRITE_T_Y);
-
-    // Need to do -1 here so that the sprite isn't at the target position and gets updated
-    run_setup_deck->sprite_object->x = run_setup_deck->sprite_object->tx - 1;
-    run_setup_deck->sprite_object->y = run_setup_deck->sprite_object->ty - 1;
+    sprite_object_position(
+        run_setup_deck->sprite_object,
+        RUN_SETUP_DECK_SPRITE_T_X,
+        RUN_SETUP_DECK_SPRITE_T_Y
+    );
 
     card_object_update(run_setup_deck);
 

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -196,10 +196,7 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 
 void sprite_object_reset_transform(SpriteObject* sprite_object)
 {
-    sprite_object->tx = 0; // Target position
-    sprite_object->ty = 0;
-    sprite_object->x = 0;
-    sprite_object->y = 0;
+    sprite_object_position(sprite_object, 0, 0); // Target position
     sprite_object->vx = 0;
     sprite_object->vy = 0;
     sprite_object->tscale = FIX_ONE; // Target scale


### PR DESCRIPTION
Closes #543.

Function is inlined for efficiency just line `sprite_position`

Although I'm starting to wonder if we should do a `position` and `target` variants of this function because in the end I couldn't use it much, since the position and target position are usually not the same to achieve some sort of animation.