### PR TITLE
Moved pools and bitsets to EWRAM

### DIFF
--- a/include/bitset.h
+++ b/include/bitset.h
@@ -196,8 +196,8 @@ int bitset_itr_next(BitsetItr* itr);
  * @param capacity the capacity of the bitset
  */
 #define BITSET_DEFINE(name, capacity)                  \
-    static uint32_t name##_w[BITSET_ARRAY_SIZE] = {0}; \
-    static Bitset name = {                             \
+    EWRAM_DATA static uint32_t name##_w[BITSET_ARRAY_SIZE] = {0}; \
+    EWRAM_DATA static Bitset name = {                             \
         .w = name##_w,                                 \
         .nbits = BITSET_BITS_PER_WORD,                 \
         .nwords = BITSET_ARRAY_SIZE,                   \

--- a/include/pool.h
+++ b/include/pool.h
@@ -25,8 +25,8 @@
 
 #define POOL_DEFINE_TYPE(type, capacity)                                \
     BITSET_DEFINE(type##_bitset, capacity)                              \
-    EWRAM_DATA static type type##_storage[capacity];                               \
-    EWRAM_DATA static type##Pool type##_pool = {                                   \
+    EWRAM_DATA static type type##_storage[capacity];                    \
+    EWRAM_DATA static type##Pool type##_pool = {                        \
         .bitset = &type##_bitset,                                       \
         .objects = type##_storage,                                      \
     };                                                                  \

--- a/include/pool.h
+++ b/include/pool.h
@@ -25,8 +25,8 @@
 
 #define POOL_DEFINE_TYPE(type, capacity)                                \
     BITSET_DEFINE(type##_bitset, capacity)                              \
-    static type type##_storage[capacity];                               \
-    static type##Pool type##_pool = {                                   \
+    EWRAM_DATA static type type##_storage[capacity];                               \
+    EWRAM_DATA static type##Pool type##_pool = {                                   \
         .bitset = &type##_bitset,                                       \
         .objects = type##_storage,                                      \
     };                                                                  \


### PR DESCRIPTION
So the issues I've seen with this are sprite flickers when rerolling.
Edit: seems like this isn't caused by this change: #568

https://github.com/user-attachments/assets/95c250b8-6a30-4a2a-8703-207010171abb

Frame by frame

<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/02ed3447-6a70-4eeb-8345-ec24d450b611" />
<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/9bea329e-d885-4f16-8c78-6d25eec35a9b" />
<img width="480" height="320" alt="image" src="https://github.com/user-attachments/assets/9d81e6b1-e20e-470f-b5c5-5ff73a050941" />


