### PR TITLE
Fixed mode argument on calls to obj_unhide

### DIFF
--- a/source/game/blind_select.c
+++ b/source/game/blind_select.c
@@ -494,7 +494,7 @@ void game_blind_select_change_background(void)
 {
     for (int i = 0; i < NUM_BLINDS_PER_ANTE; i++)
     {
-        obj_unhide(blind_select_tokens[i]->obj, 0);
+        obj_unhide(blind_select_tokens[i]->obj, ATTR0_REG);
     }
 
     // Default y position for the blind select tokens. 12 is the amount of tiles the background

--- a/source/game/round_end.c
+++ b/source/game/round_end.c
@@ -118,7 +118,7 @@ static void game_round_end_start_expand_popup(void)
 
 static void game_round_end_display_finished_blind(void)
 {
-    obj_unhide(g_game_vars.round_end_blind_token->obj, 0);
+    obj_unhide(g_game_vars.round_end_blind_token->obj, ATTR0_REG);
 
     int current_ante = g_game_vars.ante;
 

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -635,7 +635,7 @@ void game_run_setup_on_exit(void)
 static void choose_deck_substate_init(void)
 {
     // Show Deck sprite, name and TODO: description
-    obj_unhide(run_setup_deck->sprite_object->sprite->obj, 0);
+    obj_unhide(run_setup_deck->sprite_object->sprite->obj, ATTR0_AFF);
     print_deck_name(g_game_vars.deck, RUN_SETUP_DECK_NAME_TEXT_POS);
     print_deck_description(g_game_vars.deck, RUN_SETUP_DECK_DESC_TEXT_POS);
 
@@ -1095,7 +1095,7 @@ static void resume_substate_init(void)
     tab_set_highlight(RUN_SETUP_TAB_RESUME);
 
     // Show Deck card sprite
-    obj_unhide(run_setup_deck->sprite_object->sprite->obj, 0);
+    obj_unhide(run_setup_deck->sprite_object->sprite->obj, ATTR0_AFF);
 }
 
 // COMMON BUTTONS


### PR DESCRIPTION
Apparently `obj_hide()` and `obj_unhide()` override the mode bits (regular, affine, etc.) of the sprite, because they are the same bits. i.e. a sprite mode can only be one of `ATTR0_REG`, `ATTR0_AFF`, `ATTR0_HIDE`, `ATTR0_AFF_DBL`. 
Therefore `obj_unhide` accepts a mode parameter to determine which mode to return the sprite to.
So far the code just passed 0 on all calls, but that's actually a magic number and it needs to be in line with the type of the sprite so I changed that in this PR.
A more correct way to do this, is to save the sprite mode in the `Sprite` struct but that crashes so I made a separate draft PR #563  for that and this is just a quick fix in the meantime.