### PR TITLE
Add mode field to Sprite

### DIFF
--- a/include/card.h
+++ b/include/card.h
@@ -75,8 +75,8 @@ u8 card_get_value(Card* card);
 // CardObject methods
 CardObject* card_object_new(Card* card);
 void card_object_destroy(CardObject** card_object);
-void card_object_set_sprite(CardObject* card_object, int layer);
-void card_object_set_sprite_face_down(CardObject* card_object, enum DeckType deck, int layer);
+void card_object_set_sprite(CardObject* card_object, s16 layer);
+void card_object_set_sprite_face_down(CardObject* card_object, enum DeckType deck, s16 layer);
 void card_object_shake(CardObject* card_object, mm_word sound_id);
 
 void card_object_set_selected(CardObject* card_object, bool selected);

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -189,10 +189,17 @@ bool sprite_get_width(Sprite* sprite, int* width);
  */
 int sprite_get_pb(const Sprite* sprite);
 
-// TODO: Document
+/**
+ * @brief Hides the sprite by manipulating ATTR0_HIDE in OAM.
+ * @param sprite The sprite to hide
+ */
 void sprite_hide(Sprite* sprite);
 
-// TODO: Documents
+/**
+ * @brief Unhides the sprite by manipulating ATTR0_HIDE in OAM.
+ * The sprite's ATTR0_MODE is maintained from the sprite's creation with @ref sprite_new()
+ * @param sprite The sprite to unhide
+ */
 void sprite_unhide(Sprite* sprite);
 
 /**
@@ -236,8 +243,17 @@ void sprite_object_destroy(SpriteObject* sprite_object);
  */
 void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite);
 
+/**
+ * @brief Hides the SpriteObject by manipulating ATTR0_HIDE in OAM.
+ * @param sprite_object The SpriteObject to hide
+ */
 void sprite_object_hide(SpriteObject* sprite_object);
 
+/**
+ * @brief Unhides the SpriteObject by manipulating ATTR0_HIDE in OAM.
+ * The sprite's ATTR0_MODE is maintained from the sprite's creation with @ref sprite_new()
+ * @param sprite_object The SpriteObject to unhide
+ */
 void sprite_object_unhide(SpriteObject* sprite_object);
 
 /**

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -45,7 +45,7 @@ typedef struct
     /**
      * @brief Sprite index in memory managed by GBAlatro
      */
-    int idx;
+    s16 idx;
 
     /**
      * @brief The mode of the sprite (regular, affine, etc.), set when the sprite is created
@@ -127,7 +127,7 @@ typedef struct
  * @return Valid Sprite if allocations are successful.
  *         Otherwise, return **NULL**.
  */
-Sprite* sprite_new(u16 a0, u16 a1, u32 tid, u32 pb, int sprite_index);
+Sprite* sprite_new(u16 a0, u16 a1, u32 tid, u32 pb, s16 sprite_index);
 
 /**
  * @brief Destroy Sprite
@@ -143,7 +143,7 @@ void sprite_destroy(Sprite** sprite);
  *
  * @return Index of sprite in object buffer if `sprite` is valid, otherwise **UNDEFINED**.
  */
-int sprite_get_layer(Sprite* sprite);
+s16 sprite_get_layer(Sprite* sprite);
 
 /**
  * @brief Get a Sprite's width and height

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -46,6 +46,12 @@ typedef struct
      * @brief Sprite index in memory managed by GBAlatro
      */
     int idx;
+
+    /**
+     * @brief The mode of the sprite (regular, affine, etc.), set when the sprite is created
+     * corresponds to A0 & ATTR0_MODE_MASK
+     */
+    u16 mode;
 } Sprite;
 
 /**
@@ -183,6 +189,12 @@ bool sprite_get_width(Sprite* sprite, int* width);
  */
 int sprite_get_pb(const Sprite* sprite);
 
+// TODO: Document
+void sprite_hide(Sprite* sprite);
+
+// TODO: Documents
+void sprite_unhide(Sprite* sprite);
+
 /**
  * @brief Initialize GBAlatro sprite system
  */
@@ -223,6 +235,10 @@ void sprite_object_destroy(SpriteObject* sprite_object);
  *                      Cannot be **NULL**.
  */
 void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite);
+
+void sprite_object_hide(SpriteObject* sprite_object);
+
+void sprite_object_unhide(SpriteObject* sprite_object);
 
 /**
  * @brief Reset SpriteObject's transform back to default values.

--- a/source/card.c
+++ b/source/card.c
@@ -121,7 +121,7 @@ void card_object_destroy(CardObject** card_object)
     *card_object = NULL;
 }
 
-void card_object_set_sprite(CardObject* card_object, int layer)
+void card_object_set_sprite(CardObject* card_object, s16 layer)
 {
     int tile_index = CARD_TID + (layer * CARD_SPRITE_OFFSET);
     const unsigned int* card_tiles = s_more_readable ? deck_big_gfxTiles : deck_gfxTiles;
@@ -140,7 +140,7 @@ void card_object_set_sprite(CardObject* card_object, int layer)
     sprite_object_set_sprite((SpriteObject*)card_object, sprite);
 }
 
-void card_object_set_sprite_face_down(CardObject* card_object, enum DeckType deck, int layer)
+void card_object_set_sprite_face_down(CardObject* card_object, enum DeckType deck, s16 layer)
 {
     int tile_index = CARD_TID + (layer * CARD_SPRITE_OFFSET);
     memcpy32(

--- a/source/game/blind_select.c
+++ b/source/game/blind_select.c
@@ -260,7 +260,7 @@ static void game_blind_select_selected_anim_seq()
     {
         for (int i = 0; i < NUM_BLINDS_PER_ANTE; i++)
         {
-            obj_hide(blind_select_tokens[i]->obj);
+            sprite_hide(blind_select_tokens[i]);
         }
 
         s_timer = TM_ZERO;
@@ -445,7 +445,7 @@ static void blind_tokens_init()
 
     for (int i = 0; i < NUM_BLINDS_PER_ANTE; i++)
     {
-        obj_hide(blind_select_tokens[i]->obj);
+        sprite_hide(blind_select_tokens[i]);
     }
 }
 

--- a/source/game/blind_select.c
+++ b/source/game/blind_select.c
@@ -494,7 +494,7 @@ void game_blind_select_change_background(void)
 {
     for (int i = 0; i < NUM_BLINDS_PER_ANTE; i++)
     {
-        sprite_unhide(blind_select_tokens[i]->obj);
+        sprite_unhide(blind_select_tokens[i]);
     }
 
     // Default y position for the blind select tokens. 12 is the amount of tiles the background

--- a/source/game/blind_select.c
+++ b/source/game/blind_select.c
@@ -494,7 +494,7 @@ void game_blind_select_change_background(void)
 {
     for (int i = 0; i < NUM_BLINDS_PER_ANTE; i++)
     {
-        obj_unhide(blind_select_tokens[i]->obj, ATTR0_REG);
+        sprite_unhide(blind_select_tokens[i]->obj);
     }
 
     // Default y position for the blind select tokens. 12 is the amount of tiles the background

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -1990,7 +1990,7 @@ void game_round_on_init(void)
     // TODO: Hide blind token and display it after sliding blind rect animation
     // if (g_game_vars.playing_blind_token != NULL)
     //{
-    //    obj_hide(g_game_vars.playing_blind_token->obj); // Hide the blind token sprite for now
+    //    sprite_hide(g_game_vars.playing_blind_token); // Hide the blind token sprite for now
     //}
     sprite_destroy(&g_game_vars.round_end_blind_token);
     g_game_vars.round_end_blind_token = blind_token_new(
@@ -2002,7 +2002,7 @@ void game_round_on_init(void)
 
     if (g_game_vars.round_end_blind_token != NULL)
     {
-        obj_hide(g_game_vars.round_end_blind_token->obj); // Hide the blind token sprite for now
+        sprite_hide(g_game_vars.round_end_blind_token); // Hide the blind token sprite for now
     }
 
     Rect blind_req_text_rect = BLIND_REQ_TEXT_RECT;

--- a/source/game/round_end.c
+++ b/source/game/round_end.c
@@ -118,7 +118,7 @@ static void game_round_end_start_expand_popup(void)
 
 static void game_round_end_display_finished_blind(void)
 {
-    sprite_unhide(g_game_vars.round_end_blind_token->obj);
+    sprite_unhide(g_game_vars.round_end_blind_token);
 
     int current_ante = g_game_vars.ante;
 
@@ -412,7 +412,7 @@ static void game_round_end_display_cashout()
         g_game_vars.timer = TM_ZERO;
 
         sprite_hide(g_game_vars.round_end_blind_token); // Hide the blind token object
-        tte_erase_rect_wrapper(BLIND_TOKEN_TEXT_RECT);    // Erase the blind token text
+        tte_erase_rect_wrapper(BLIND_TOKEN_TEXT_RECT); // Erase the blind token text
     }
 }
 

--- a/source/game/round_end.c
+++ b/source/game/round_end.c
@@ -208,7 +208,7 @@ static void game_round_end_update_blind_reward(void)
     {
         tte_erase_rect_wrapper(BLIND_REWARD_RECT);
         tte_erase_rect_wrapper(BLIND_REQ_TEXT_RECT);
-        obj_hide(g_game_vars.playing_blind_token->obj);
+        sprite_hide(g_game_vars.playing_blind_token);
         affine_background_load_palette(affine_background_gfxPal);
         state_machine_change_state(&round_end_sm, BLIND_PANEL_EXIT);
         g_game_vars.timer = TM_ZERO;
@@ -411,7 +411,7 @@ static void game_round_end_display_cashout()
         state_machine_change_state(&round_end_sm, DISMISS_ROUND_END_PANEL);
         g_game_vars.timer = TM_ZERO;
 
-        obj_hide(g_game_vars.round_end_blind_token->obj); // Hide the blind token object
+        sprite_hide(g_game_vars.round_end_blind_token); // Hide the blind token object
         tte_erase_rect_wrapper(BLIND_TOKEN_TEXT_RECT);    // Erase the blind token text
     }
 }

--- a/source/game/round_end.c
+++ b/source/game/round_end.c
@@ -412,7 +412,7 @@ static void game_round_end_display_cashout()
         g_game_vars.timer = TM_ZERO;
 
         sprite_hide(g_game_vars.round_end_blind_token); // Hide the blind token object
-        tte_erase_rect_wrapper(BLIND_TOKEN_TEXT_RECT); // Erase the blind token text
+        tte_erase_rect_wrapper(BLIND_TOKEN_TEXT_RECT);  // Erase the blind token text
     }
 }
 

--- a/source/game/round_end.c
+++ b/source/game/round_end.c
@@ -118,7 +118,7 @@ static void game_round_end_start_expand_popup(void)
 
 static void game_round_end_display_finished_blind(void)
 {
-    obj_unhide(g_game_vars.round_end_blind_token->obj, ATTR0_REG);
+    sprite_unhide(g_game_vars.round_end_blind_token->obj);
 
     int current_ante = g_game_vars.ante;
 

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -650,13 +650,7 @@ void game_run_setup_on_exit(void)
 static void choose_deck_substate_init(void)
 {
     // Show Deck sprite, name and TODO: description
-    {
-        Sprite* deck_sprite = sprite_object_get_sprite((SpriteObject*)run_setup_deck);
-        if (deck_sprite != NULL)
-        {
-            obj_unhide(deck_sprite->obj, ATTR0_AFF);
-        }
-    }
+    sprite_object_unhide((SpriteObject*)run_setup_deck);
     print_deck_name(g_game_vars.deck, RUN_SETUP_DECK_NAME_TEXT_POS);
     print_deck_description(g_game_vars.deck, RUN_SETUP_DECK_DESC_TEXT_POS);
 

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -821,13 +821,7 @@ static void seed_keyboard_substate_init(void)
     tte_erase_rect_wrapper(RUN_SETUP_DECK_NAME_DESC_RECT);
 
     // Hide Deck card sprite
-    {
-        Sprite* deck_sprite = sprite_object_get_sprite((SpriteObject*)run_setup_deck);
-        if (deck_sprite != NULL)
-        {
-            obj_hide(deck_sprite->obj);
-        }
-    }
+    sprite_object_hide((SpriteObject*)run_setup_deck);
 
     // Clean deck swap screen with frame BG color
     main_bg_se_copy_expand_tile(
@@ -1122,13 +1116,7 @@ static void resume_substate_init(void)
     tab_set_highlight(RUN_SETUP_TAB_RESUME);
 
     // Show Deck card sprite
-    {
-        Sprite* deck_sprite = sprite_object_get_sprite((SpriteObject*)run_setup_deck);
-        if (deck_sprite != NULL)
-        {
-            obj_unhide(deck_sprite->obj, ATTR0_AFF);
-        }
-    }
+    sprite_object_unhide((SpriteObject*)run_setup_deck);
 }
 
 // COMMON BUTTONS

--- a/source/joker.c
+++ b/source/joker.c
@@ -253,7 +253,7 @@ void joker_object_destroy(JokerObject** joker_object)
     if (joker_object == NULL || *joker_object == NULL)
         return;
 
-    int layer = sprite_get_layer(joker_object_get_sprite(*joker_object)) - JOKER_STARTING_LAYER;
+    s16 layer = sprite_get_layer(joker_object_get_sprite(*joker_object)) - JOKER_STARTING_LAYER;
     s_used_layers[layer] = false;
     s_joker_pb_remove_sprite_user(sprite_get_pb(joker_object_get_sprite(*joker_object)));
     if (s_joker_pb_get_num_sprite_users((sprite_get_pb(joker_object_get_sprite(*joker_object)))) ==

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -165,19 +165,19 @@ void sprite_draw()
 
 int sprite_get_pb(const Sprite* sprite)
 {
-    CHECK_NULL_ARG_RET(sprite, UNDEFINED);
+    GBAL_RETURN_IF_NULL_RET(sprite, UNDEFINED);
     return (sprite->obj->attr2 & ATTR2_PALBANK_MASK) >> ATTR2_PALBANK_SHIFT;
 }
 
 void sprite_hide(Sprite* sprite)
 {
-    CHECK_NULL_ARG_VOID(sprite);
+    GBAL_RETURN_IF_NULL_VOID(sprite);
     obj_hide(sprite->obj);
 }
 
 void sprite_unhide(Sprite* sprite)
 {
-    CHECK_NULL_ARG_VOID(sprite);
+    GBAL_RETURN_IF_NULL_VOID(sprite);
     obj_unhide(sprite->obj, sprite->mode);
 }
 
@@ -213,13 +213,13 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 
 void sprite_object_hide(SpriteObject* sprite_object)
 {
-    CHECK_NULL_ARG_VOID(sprite_object);
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
     sprite_hide(sprite_object->sprite);
 }
 
 void sprite_object_unhide(SpriteObject* sprite_object)
 {
-    CHECK_NULL_ARG_VOID(sprite_object);
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
     sprite_unhide(sprite_object->sprite);
 }
 

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -33,7 +33,7 @@ static bool free_affines[MAX_AFFINES] = {false};
 static List sprite_objects_list = LIST_DEFAULT;
 
 // Sprite methods
-Sprite* sprite_new(u16 a0, u16 a1, u32 tid, u32 pb, int sprite_index)
+Sprite* sprite_new(u16 a0, u16 a1, u32 tid, u32 pb, s16 sprite_index)
 {
     Sprite* sprite = POOL_GET(Sprite);
 
@@ -109,11 +109,11 @@ void sprite_destroy(Sprite** sprite)
     *sprite = NULL;
 }
 
-int sprite_get_layer(Sprite* sprite)
+s16 sprite_get_layer(Sprite* sprite)
 {
     if (sprite == NULL || sprite->obj == NULL)
         return UNDEFINED;
-    return sprite->obj - obj_buffer;
+    return (s16)(sprite->obj - obj_buffer);
 }
 
 bool sprite_get_width(Sprite* sprite, int* width)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -85,6 +85,8 @@ Sprite* sprite_new(u16 a0, u16 a1, u32 tid, u32 pb, int sprite_index)
 
     sprite->idx = sprite_index;
 
+    sprite->mode = a0 & ATTR0_MODE_MASK;
+
     return sprite;
 }
 
@@ -163,11 +165,20 @@ void sprite_draw()
 
 int sprite_get_pb(const Sprite* sprite)
 {
-    if (sprite == NULL)
-    {
-        return UNDEFINED;
-    }
+    CHECK_NULL_ARG_RET(sprite, UNDEFINED);
     return (sprite->obj->attr2 & ATTR2_PALBANK_MASK) >> ATTR2_PALBANK_SHIFT;
+}
+
+void sprite_hide(Sprite* sprite)
+{
+    CHECK_NULL_ARG_VOID(sprite);
+    obj_hide(sprite->obj);
+}
+
+void sprite_unhide(Sprite* sprite)
+{
+    CHECK_NULL_ARG_VOID(sprite);
+    obj_unhide(sprite->obj, sprite->mode);
 }
 
 // SpriteObject methods
@@ -198,6 +209,18 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
         return;
     sprite_destroy(&sprite_object->sprite); // Destroy the old sprite if it exists
     sprite_object->sprite = sprite;
+}
+
+void sprite_object_hide(SpriteObject* sprite_object)
+{
+    CHECK_NULL_ARG_VOID(sprite_object);
+    sprite_hide(sprite_object->sprite);
+}
+
+void sprite_object_unhide(SpriteObject* sprite_object)
+{
+    CHECK_NULL_ARG_VOID(sprite_object);
+    sprite_unhide(sprite_object->sprite);
 }
 
 void sprite_object_reset_transform(SpriteObject* sprite_object)

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -109,19 +109,21 @@ void sprite_destroy(Sprite** sprite)
     *sprite = NULL;
 }
 
+/* The following functions don't check sprite->obj, assuming it shouldn't be NULL
+ * if sprite != NULL since it's set in the constructor
+ */
+
 s16 sprite_get_layer(Sprite* sprite)
 {
-    if (sprite == NULL || sprite->obj == NULL)
-        return UNDEFINED;
+    GBAL_RETURN_IF_NULL_RET(sprite, UNDEFINED);
+
     return (s16)(sprite->obj - obj_buffer);
 }
 
 bool sprite_get_width(Sprite* sprite, int* width)
 {
-    if (sprite == NULL || sprite->obj == NULL || width == NULL)
-    {
-        return false;
-    }
+    GBAL_RETURN_IF_NULL_RET(sprite, false);
+    GBAL_RETURN_IF_NULL_RET(width, false);
 
     *width = obj_get_width(sprite->obj);
     return true;
@@ -129,10 +131,8 @@ bool sprite_get_width(Sprite* sprite, int* width)
 
 bool sprite_get_height(Sprite* sprite, int* height)
 {
-    if (sprite == NULL || sprite->obj == NULL || height == NULL)
-    {
-        return false;
-    }
+    GBAL_RETURN_IF_NULL_RET(sprite, false);
+    GBAL_RETURN_IF_NULL_RET(height, false);
 
     *height = obj_get_height(sprite->obj);
     return true;
@@ -140,10 +140,9 @@ bool sprite_get_height(Sprite* sprite, int* height)
 
 bool sprite_get_dimensions(Sprite* sprite, int* width, int* height)
 {
-    if (sprite == NULL || sprite->obj == NULL || width == NULL || height == NULL)
-    {
-        return false;
-    }
+    GBAL_RETURN_IF_NULL_RET(sprite, false);
+    GBAL_RETURN_IF_NULL_RET(width, false);
+    GBAL_RETURN_IF_NULL_RET(height, false);
 
     const u8* size = obj_get_size(sprite->obj);
     *width = size[0];
@@ -166,18 +165,21 @@ void sprite_draw()
 int sprite_get_pb(const Sprite* sprite)
 {
     GBAL_RETURN_IF_NULL_RET(sprite, UNDEFINED);
+
     return (sprite->obj->attr2 & ATTR2_PALBANK_MASK) >> ATTR2_PALBANK_SHIFT;
 }
 
 void sprite_hide(Sprite* sprite)
 {
     GBAL_RETURN_IF_NULL_VOID(sprite);
+
     obj_hide(sprite->obj);
 }
 
 void sprite_unhide(Sprite* sprite)
 {
     GBAL_RETURN_IF_NULL_VOID(sprite);
+
     obj_unhide(sprite->obj, sprite->mode);
 }
 
@@ -195,18 +197,16 @@ void sprite_object_init(SpriteObject* sprite_object)
 
 void sprite_object_destroy(SpriteObject* sprite_object)
 {
-    if (sprite_object == NULL)
-        return;
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
 
     list_remove_data(&sprite_objects_list, sprite_object);
-
     sprite_destroy(&sprite_object->sprite);
 }
 
 void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 {
-    if (sprite_object == NULL)
-        return;
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     sprite_destroy(&sprite_object->sprite); // Destroy the old sprite if it exists
     sprite_object->sprite = sprite;
 }
@@ -214,17 +214,21 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 void sprite_object_hide(SpriteObject* sprite_object)
 {
     GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     sprite_hide(sprite_object->sprite);
 }
 
 void sprite_object_unhide(SpriteObject* sprite_object)
 {
     GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     sprite_unhide(sprite_object->sprite);
 }
 
 void sprite_object_reset_transform(SpriteObject* sprite_object)
 {
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     sprite_object_position(sprite_object, 0, 0); // Target position
     sprite_object->vx = 0;
     sprite_object->vy = 0;
@@ -235,6 +239,10 @@ void sprite_object_reset_transform(SpriteObject* sprite_object)
     sprite_object->rotation = 0;
     sprite_object->vrotation = 0;
 }
+
+/* The following functions are in the SpriteObject update loop which is called each frame
+ * so they avoid argument NULL-checks for efficiency.
+ */
 
 static inline bool sprite_object_has_velocity(const SpriteObject* sprite_object)
 {
@@ -342,8 +350,7 @@ void sprite_object_update_all(void)
 
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 {
-    if (sprite_object == NULL)
-        return;
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
 
     sprite_object->vscale = float2fx(0.3f);
     sprite_object->vrotation = float2fx(8.0f); // Rotate the card when it's scored
@@ -356,13 +363,15 @@ void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 
 Sprite* sprite_object_get_sprite(SpriteObject* sprite_object)
 {
-    if (sprite_object == NULL)
-        return NULL;
+    GBAL_RETURN_IF_NULL_RET(sprite_object, NULL);
+
     return sprite_object->sprite;
 }
 
 void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 {
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     if (sprite_object->focused == focus)
     {
         return;
@@ -379,36 +388,28 @@ void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 
 bool sprite_object_get_width(SpriteObject* sprite_object, int* width)
 {
-    if (sprite_object == NULL)
-    {
-        return false;
-    }
+    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
 
     return sprite_get_width(sprite_object->sprite, width);
 }
 
 bool sprite_object_get_height(SpriteObject* sprite_object, int* height)
 {
-    if (sprite_object == NULL)
-    {
-        return false;
-    }
+    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
 
     return sprite_get_height(sprite_object->sprite, height);
 }
 
 bool sprite_object_get_dimensions(SpriteObject* sprite_object, int* width, int* height)
 {
-    if (sprite_object == NULL)
-    {
-        return false;
-    }
+    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
 
     return sprite_get_dimensions(sprite_object->sprite, width, height);
 }
 
 bool sprite_object_is_focused(SpriteObject* sprite_object)
 {
+    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
     return sprite_object->focused;
 }
 
@@ -416,6 +417,9 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
 {
     int height = 0;
     int width = 0;
+    Rect ret_rect = {0};
+
+    GBAL_RETURN_IF_NULL_RET(sprite_object, ret_rect);
 
     if (sprite_object_get_dimensions(sprite_object, &width, &height) == false)
     {
@@ -423,8 +427,6 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
         height = CARD_SPRITE_SIZE;
         width = CARD_SPRITE_SIZE;
     }
-
-    Rect ret_rect = {0};
 
     ret_rect.left = fx2int(sprite_object->tx);
     ret_rect.top = fx2int(sprite_object->ty) + height + TILE_SIZE;
@@ -436,15 +438,17 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
 
 void sprite_object_print_text_under(SpriteObject* sprite_object, const char text[])
 {
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
-
     update_text_rect_to_center_str(&text_rect, text, SCREEN_LEFT);
-
     tte_printf("#{P:%d,%d; cx:0x%X000}%s", text_rect.left, text_rect.top, TTE_YELLOW_PB, text);
 }
 
 void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 {
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     // + 2 for null-terminator and "$"
     char price_str_buff[INT_MAX_DIGITS + 2];
     snprintf(price_str_buff, sizeof(price_str_buff), "$%d", price);
@@ -453,6 +457,8 @@ void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 
 void sprite_object_erase_text_under(SpriteObject* sprite_object)
 {
+    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
 
     // Add SPRITE_FOCUS_RAISE_PX to cover the focused case


### PR DESCRIPTION
See #562.

As said, this PR crashes, still not entirely sure why, but it seems like moving the pools to EWRAM helps?
See #560

Edit: I rebased on main and it seems to not crash now...? So I'm setting as ready for review.

This PR just adds a sprite hiding API to save the mode in the sprite instead of always calling `obj_hide` and needing to pass the correct mode, ensuring correctness and making it less error-prone.