### PR TITLE
[Refactor] Moved `reset_top_left_panel_bottom_row()` to common_ui.c/.h

### DIFF
--- a/include/game/common_ui.h
+++ b/include/game/common_ui.h
@@ -33,4 +33,9 @@ enum BackgroundId get_current_background(void);
  */
 void change_background(enum BackgroundId id, bool force_redraw);
 
+/**
+ * @brief Restores the bottom row of the top-left panel from the background map.
+ */
+void reset_top_left_panel_bottom_row(void);
+
 #endif // COMMON_UI_H

--- a/include/graphic_utils.h
+++ b/include/graphic_utils.h
@@ -511,11 +511,6 @@ void memcpy32_tile8_with_palette_offset(u32* dst, const u32* src, uint wcount, u
 void toggle_windows(bool win0, bool win1);
 
 /**
- * @brief Restores the bottom row of the top-left panel from the background map.
- */
-void reset_top_left_panel_bottom_row(void);
-
-/**
  * @brief Justify a text with custom formatting tags according to the given
  *         justification and bias direction tags
  *

--- a/include/layout.h
+++ b/include/layout.h
@@ -9,21 +9,22 @@
 #include "graphic_utils.h"
 
 // clang-format off
-// Points                                               x        y
-static const BG_POINT CUR_BLIND_TOKEN_POS            = {8,       18};
-static const BG_POINT TOP_LEFT_PANEL_POINT           = {0,       0};
-static const BG_POINT ROUND_END_REWARDS_ELLIPSIS_POS = {10,      13};
-static const BG_POINT JOKER_DISCARD_TARGET           = {240,     30};
-static const BG_POINT HELD_JOKERS_POS                = {108,     10};
-// Rects                                                left     top     right   bottom
-static const Rect TOP_LEFT_PANEL_ANIM_RECT           = {0,       0,      8,      4};
-static const Rect POP_MENU_ANIM_RECT                 = {9,       7,      24,     31};
-static const Rect DECK_ANIM_RECT                     = {25,      14,     28,     23}; // Can be used for the Shop and Blind Select screen
-static const Rect TOP_LEFT_ITEM_SRC_RECT             = {0,       20,     8,      25};
-static const Rect BLIND_REWARD_RECT                  = {40,      32,     64,     40};
-static const Rect BLIND_REQ_TEXT_RECT                = {32,      24,     64,     32};
-static const Rect PLAYING_SCREEN_RECT                = {72,      0,      240,    160};
-static const Rect HAND_SIZE_RECT                     = {128,     128,    152,    160}; // Seems to include both SELECT and PLAYING
+// Points                                                 x        y
+static const BG_POINT CUR_BLIND_TOKEN_POS              = {8,       18};
+static const BG_POINT TOP_LEFT_PANEL_POINT             = {0,       0};
+static const BG_POINT ROUND_END_REWARDS_ELLIPSIS_POS   = {10,      13};
+static const BG_POINT JOKER_DISCARD_TARGET             = {240,     30};
+static const BG_POINT HELD_JOKERS_POS                  = {108,     10};
+// Rects                                                  left     top     right   bottom
+static const Rect TOP_LEFT_PANEL_ANIM_RECT             = {0,       0,      8,      4};
+static const Rect POP_MENU_ANIM_RECT                   = {9,       7,      24,     31};
+static const Rect DECK_ANIM_RECT                       = {25,      14,     28,     23}; // Can be used for the Shop and Blind Select screen
+static const Rect TOP_LEFT_ITEM_SRC_RECT               = {0,       20,     8,      25};
+static const Rect TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT = {0,       28,     8,      28};
+static const Rect BLIND_REWARD_RECT                    = {40,      32,     64,     40};
+static const Rect BLIND_REQ_TEXT_RECT                  = {32,      24,     64,     32};
+static const Rect PLAYING_SCREEN_RECT                  = {72,      0,      240,    160};
+static const Rect HAND_SIZE_RECT                       = {128,     128,    152,    160}; // Seems to include both SELECT and PLAYING
 // clang-format on
 
 #endif // LAYOUT_H

--- a/source/game/common_ui.c
+++ b/source/game/common_ui.c
@@ -8,6 +8,7 @@
 #include "game/round_end.h"
 #include "game/run_setup.h"
 #include "game/shop.h"
+#include "layout.h"
 
 typedef void (*BackgroundRenderCallback)(void);
 
@@ -42,4 +43,12 @@ void change_background(enum BackgroundId id, bool force_redraw)
         bgCallbacks[id]();
     }
     background = id;
+}
+
+void reset_top_left_panel_bottom_row(void)
+{
+    BG_POINT top_left_panel_bottom_row_pos = TOP_LEFT_PANEL_POINT;
+    // Use the source rect height to offset to the bottom row point
+    top_left_panel_bottom_row_pos.y += rect_height(&TOP_LEFT_ITEM_SRC_RECT) - 1;
+    main_bg_se_copy_rect(TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT, top_left_panel_bottom_row_pos);
 }

--- a/source/graphic_utils.c
+++ b/source/graphic_utils.c
@@ -9,7 +9,6 @@
 #include <tonc_tte.h>
 
 static const Rect FULL_SCREENBLOCK_RECT = {0, 0, SE_ROW_LEN - 1, SE_COL_LEN - 1};
-static const Rect TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT = {0, 28, 8, 28};
 
 static void clip_se_rect_to_screenblock(Rect* rect);
 static void bg_se_copy_or_move_rect_1_tile_vert(
@@ -499,14 +498,6 @@ void main_bg_se_clear_rect(Rect se_rect)
     {
         memset16(&(se_mat[MAIN_BG_SBB][y][se_rect.left]), 0x0000, rect_width(&se_rect));
     }
-}
-
-void reset_top_left_panel_bottom_row(void)
-{
-    BG_POINT top_left_panel_bottom_row_pos = TOP_LEFT_PANEL_POINT;
-    // Use the source rect height to offset to the bottom row point
-    top_left_panel_bottom_row_pos.y += rect_height(&TOP_LEFT_ITEM_SRC_RECT) - 1;
-    main_bg_se_copy_rect(TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT, top_left_panel_bottom_row_pos);
 }
 
 // Width of the screen, in nb of tiles


### PR DESCRIPTION
I wanted to keep the functions in graphic_utils.c/.h more generic and `reset_top_left_panel_bottom_row()` is more specific to the game.
I moved it to common_ui.c/.h, so far it only has background setting functions but since it's in the game directory and called "common" I thought it was a fitting place.

I also want to move the game-specific constant definitions away from graphic_utils.h, still not sure where though.