### PR TITLE
Removed call to `obj_aff_copy()` from `sprite_draw()`

### DIFF
--- a/source/sprite.c
+++ b/source/sprite.c
@@ -157,7 +157,6 @@ void sprite_init()
 
 void sprite_draw()
 {
-    obj_aff_copy(obj_aff_mem, obj_aff_buffer, MAX_AFFINES);
     oam_copy(oam_mem, obj_buffer, MAX_SPRITES);
 }
 


### PR DESCRIPTION
Since `obj_aff_buffer` just points to `obj_buffer` ([with interleaved content](https://gbadev.net/tonc/regobj.html#sec-oam)), the call to `oam_copy()` in `sprite_draw()` copies both the regular sprite data and the affine data, overriding the call to `obj_aff_copy()` and making it redundant.
So I removed that call to improve performance a little bit.