### PR TITLE
[Bug] Implement independent RNG sequences to avoid interferences

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -12,6 +12,7 @@
 #define ITEM_H
 
 #include "mgba_logger.h"
+#include "random.h"
 #include "sprite.h"
 
 // TODO: Merge these with GBAL_RETURN_IF_NULL macros?
@@ -95,7 +96,7 @@ typedef struct ItemFuncs
      * All items must implement the following since they are called by the shop and all items
      * must be capable of appearing in the shop.
      */
-    Item* (*roll_new)(void);
+    Item* (*roll_new)(enum RngSequence key);
     int (*get_buy_price)(Item* item);
     bool (*can_acquire)(Item* item);
     void (*acquire)(Item* item);
@@ -113,10 +114,11 @@ typedef struct ItemFuncs
  * Matches @ref ItemFuncs.roll_new()
  *
  * @param item_type The type of the item to roll
+ * @param key to the RNG sequence used to roll the Item
  *
  * @return The newly created randomly rolled item
  */
-Item* item_roll_new(enum ItemType item_type);
+Item* item_roll_new(enum ItemType item_type, enum RngSequence key);
 
 /**
  * @brief Returns the buy price of the item.

--- a/include/joker.h
+++ b/include/joker.h
@@ -256,6 +256,5 @@ bool joker_object_score(
 );
 
 Sprite* joker_object_get_sprite(JokerObject* joker_object);
-int joker_get_random_rarity();
 
 #endif // JOKER_H

--- a/include/joker.h
+++ b/include/joker.h
@@ -10,6 +10,7 @@
 #include "game.h"
 #include "graphic_utils.h"
 #include "item.h"
+#include "random.h"
 
 #include <maxmod.h>
 
@@ -238,9 +239,11 @@ void joker_reset_rollable_jokers(void);
 /**
  * @brief Roll and create a new JokerObject item.
  *
+ * @param key to the RNG sequence that will be used to roll the Joker ID.
+ *
  * @return Newly created `Item*` (JokerObject) or NULL if none available.
  */
-Item* joker_object_roll_new(void);
+Item* joker_object_roll_new(enum RngSequence key);
 
 // This scores the joker and returns true if it was scored successfully
 // card_object = NULL means the joker_event does not concern a particular Card, i.e. Independend or

--- a/include/random.h
+++ b/include/random.h
@@ -12,6 +12,17 @@
 
 #include <tonc.h>
 
+enum RngType
+{
+    RNG_TYPE_CARD_SHUFFLE,
+    RNG_TYPE_BLIND,
+    RNG_TYPE_SHOP_ITEMS,
+    RNG_TYPE_SKIP_TAGS,
+    RNG_TYPE_JOKER_EFFECTS,
+    RNG_TYPE_MISC,
+    RNG_TYPE_MAX
+};
+
 /**
  * @brief Information to track and restore RNG state
  */
@@ -19,8 +30,8 @@ typedef struct
 {
     /** Initial seed */
     u32 seed;
-    /** Position in the rng sequence. */
-    u32 step;
+    /** Individual states for independent rng sequences */
+    u32 states[RNG_TYPE_MAX];
 } RngInfo;
 
 /**
@@ -52,15 +63,20 @@ void rng_set_seed(u32 seed);
 void rng_shuffle_seed(void);
 
 /**
- * @brief Get the next "randomly" generated number in the sequence from the current seed.
+ * @brief Get the next "randomly" generated number in the sequence corresponding to the given type.
+ *
+ * @note Custom rng had to be implemented to be able to manage several independent sequences, since
+ *        `initstate` and `setstate` are POSIX and not available on GBA via devkitpro.
+ *
+ * @param type rng key to the sequence we need to pull a random number from
  *
  * @return u32
  */
-u32 rng_get_u32(void);
+u32 rng_get_u32(enum RngType type);
 
 /**
- * @brief Restore RNG info struct in the GameVariables. Sets the `seed` and seeks the
- *         position `step` in the rng sequence.
+ * @brief Restore RNG info struct in the GameVariables. Sets the `seed` and restores the state for
+ *         each independent sequence
  *
  * @param info RngInfo struct applied
  *

--- a/include/random.h
+++ b/include/random.h
@@ -46,7 +46,7 @@ typedef struct
 } RngInfo;
 
 /**
- * @brief Starts counting CPU cycles, this will be used by rng_shuffle_seed to
+ * @brief Starts counting CPU cycles, which will be used by rng_shuffle_seed to
  *         generate a more random seed. To be called once on game start.
  */
 void rng_init(void);
@@ -66,10 +66,15 @@ void rng_update(void);
 void rng_set_seed(u32 seed);
 
 /**
- * @brief Uses the CPU cycles counter to randomize the RNG seed as much as possible.
- *         This will be called by the main menu and the game over screens so that
- *         the next run's seed isn't the same as the last's.
- *         rng_start_sampling needs to have been called, and will stop the profiling.
+ * @brief Sets a new randomized seed for the RNG using a source of entropy.
+ *
+ * This needs to be called at least once before generating anything random but not on the very
+ * first cycle because it uses a CPU timer for entropy.
+ *
+ * This would also be used to generate the new seed when starting a new non-player-seeded run
+ *
+ * @note `rng_init` needs to have been called, so that the CPU profiling can provide entropy.
+ * @sa rng_init
  */
 void rng_shuffle_seed(void);
 

--- a/include/random.h
+++ b/include/random.h
@@ -22,17 +22,13 @@ enum RngSequence
     RNG_SEQ_SHOP_ITEMS,
     RNG_SEQ_SKIP_TAGS,
 
-    /**
-     * Each Joker with a random effect has its own independent RNG sequence
-     */
+    // Each Joker with a random effect has its own independent RNG sequence
     RNG_SEQ_JOKER_MISPRINT,
     RNG_SEQ_JOKER_RESERVED_PARKING,
     RNG_SEQ_JOKER_BUSINESS_CARD,
 
-    /**
-     * @brief For non-gameplay related things such as sound effects or visual effects, so as to not
-     *         interfere with important stuff like Shop rolls or Joker effects.
-     */
+    // For non-gameplay related things such as sound effects or visual effects, so as to not
+    // interfere with important stuff like Shop rolls or Joker effects.
     RNG_SEQ_MISC,
 
     RNG_SEQ_MAX

--- a/include/random.h
+++ b/include/random.h
@@ -23,20 +23,10 @@ enum RngSequence
     RNG_SEQ_SKIP_TAGS,
 
     /**
-     * @brief Used for rolling the Misprint Joker value.
-     *
-     * Each Joker with a random effect has its own indpendent RNG sequence
+     * Each Joker with a random effect has its own independent RNG sequence
      */
     RNG_SEQ_JOKER_MISPRINT,
-
-    /**
-     * @brief Used to determine if the Reserved Parking Joker triggers.
-     */
     RNG_SEQ_JOKER_RESERVED_PARKING,
-
-    /**
-     * @brief Used to determine if the Business Card Joker triggers.
-     */
     RNG_SEQ_JOKER_BUSINESS_CARD,
 
     /**

--- a/include/random.h
+++ b/include/random.h
@@ -12,15 +12,40 @@
 
 #include <tonc.h>
 
-enum RngType
+/**
+ * @brief Keys to different independent RNG sequences
+ */
+enum RngSequence
 {
-    RNG_TYPE_CARD_SHUFFLE,
-    RNG_TYPE_BLIND,
-    RNG_TYPE_SHOP_ITEMS,
-    RNG_TYPE_SKIP_TAGS,
-    RNG_TYPE_JOKER_EFFECTS,
-    RNG_TYPE_MISC,
-    RNG_TYPE_MAX
+    RNG_SEQ_CARD_SHUFFLE,
+    RNG_SEQ_BLIND,
+    RNG_SEQ_SHOP_ITEMS,
+    RNG_SEQ_SKIP_TAGS,
+
+    /**
+     * @brief Used for rolling the Misprint Joker value.
+     *
+     * Each Joker with a random effect has its own indpendent RNG sequence
+     */
+    RNG_SEQ_JOKER_MISPRINT,
+
+    /**
+     * @brief Used to determine if the Reserved Parking Joker triggers.
+     */
+    RNG_SEQ_JOKER_RESERVED_PARKING,
+
+    /**
+     * @brief Used to determine if the Business Card Joker triggers.
+     */
+    RNG_SEQ_JOKER_BUSINESS_CARD,
+
+    /**
+     * @brief For non-gameplay related things such as sound effects or visual effects, so as to not
+     *         interfere with important stuff like Shop rolls or Joker effects.
+     */
+    RNG_SEQ_MISC,
+
+    RNG_SEQ_MAX
 };
 
 /**
@@ -31,7 +56,7 @@ typedef struct
     /** Initial seed */
     u32 seed;
     /** Individual states for independent rng sequences */
-    u32 states[RNG_TYPE_MAX];
+    u32 states[RNG_SEQ_MAX];
 } RngInfo;
 
 /**
@@ -65,14 +90,11 @@ void rng_shuffle_seed(void);
 /**
  * @brief Get the next "randomly" generated number in the sequence corresponding to the given type.
  *
- * @note Custom rng had to be implemented to be able to manage several independent sequences, since
- *        `initstate` and `setstate` are POSIX and not available on GBA via devkitpro.
- *
- * @param type rng key to the sequence we need to pull a random number from
+ * @param key key to the RNG sequence we need to pull a random number from
  *
  * @return u32
  */
-u32 rng_get_u32(enum RngType type);
+u32 rng_get_u32(enum RngSequence key);
 
 /**
  * @brief Restore RNG info struct in the GameVariables. Sets the `seed` and restores the state for

--- a/source/blind.c
+++ b/source/blind.c
@@ -171,7 +171,7 @@ enum BlindType roll_blind_type(bool showdown)
     }
 
     // roll a random blind among the unbeaten ones
-    int random_blind_idx = rng_get_u32() % list_get_len(p_unbeaten_blinds);
+    int random_blind_idx = rng_get_u32(RNG_TYPE_BLIND) % list_get_len(p_unbeaten_blinds);
     Blind* random_blind = list_get_at_idx(p_unbeaten_blinds, random_blind_idx);
 
     return random_blind->type;

--- a/source/blind.c
+++ b/source/blind.c
@@ -171,7 +171,7 @@ enum BlindType roll_blind_type(bool showdown)
     }
 
     // roll a random blind among the unbeaten ones
-    int random_blind_idx = rng_get_u32(RNG_TYPE_BLIND) % list_get_len(p_unbeaten_blinds);
+    int random_blind_idx = rng_get_u32(RNG_SEQ_BLIND) % list_get_len(p_unbeaten_blinds);
     Blind* random_blind = list_get_at_idx(p_unbeaten_blinds, random_blind_idx);
 
     return random_blind->type;

--- a/source/game.c
+++ b/source/game.c
@@ -98,7 +98,7 @@ static StateMachine game_sm = STATE_MACHINE_DEFINE(state_info, GAME_STATE_MAX);
 GameVariables g_game_vars = {
     .timer = 0,
     // Setting the seed to an invalid value so that the Run Setup screen knows we're not reusing a previous Run's seed
-    .rng_info = {UNDEFINED, 0},
+    .rng_info = {UNDEFINED, {0}},
 
     .round = 0, .ante = 0, .money = 0, .hand_size = DEFAULT_HAND_SIZE,
     .deck = DECK_TYPE_RED,
@@ -645,7 +645,7 @@ void deck_shuffle(void)
 {
     for (int i = s_deck_top; i > 0; i--)
     {
-        int j = rng_get_u32() % (i + 1);
+        int j = rng_get_u32(RNG_TYPE_CARD_SHUFFLE) % (i + 1);
         Card* temp = s_deck[i];
         s_deck[i] = s_deck[j];
         s_deck[j] = temp;

--- a/source/game.c
+++ b/source/game.c
@@ -645,7 +645,7 @@ void deck_shuffle(void)
 {
     for (int i = s_deck_top; i > 0; i--)
     {
-        int j = rng_get_u32(RNG_TYPE_CARD_SHUFFLE) % (i + 1);
+        int j = rng_get_u32(RNG_SEQ_CARD_SHUFFLE) % (i + 1);
         Card* temp = s_deck[i];
         s_deck[i] = s_deck[j];
         s_deck[j] = temp;

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -589,7 +589,7 @@ static bool game_round_hand_row_on_selection_changed(
              */
             play_sfx(
                 SFX_CARD_FOCUS,
-                MM_BASE_PITCH_RATE + rng_get_u32() % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
+                MM_BASE_PITCH_RATE + rng_get_u32(RNG_TYPE_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
                 SFX_DEFAULT_VOLUME
             );
         }
@@ -609,7 +609,7 @@ static bool game_round_hand_row_on_selection_changed(
              */
             play_sfx(
                 SFX_CARD_FOCUS,
-                MM_BASE_PITCH_RATE + rng_get_u32() % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
+                MM_BASE_PITCH_RATE + rng_get_u32(RNG_TYPE_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
                 SFX_DEFAULT_VOLUME
             );
         }

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -589,7 +589,7 @@ static bool game_round_hand_row_on_selection_changed(
              */
             play_sfx(
                 SFX_CARD_FOCUS,
-                MM_BASE_PITCH_RATE + rng_get_u32(RNG_TYPE_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
+                MM_BASE_PITCH_RATE + rng_get_u32(RNG_SEQ_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
                 SFX_DEFAULT_VOLUME
             );
         }
@@ -609,7 +609,7 @@ static bool game_round_hand_row_on_selection_changed(
              */
             play_sfx(
                 SFX_CARD_FOCUS,
-                MM_BASE_PITCH_RATE + rng_get_u32(RNG_TYPE_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
+                MM_BASE_PITCH_RATE + rng_get_u32(RNG_SEQ_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
                 SFX_DEFAULT_VOLUME
             );
         }

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -918,7 +918,7 @@ static inline void reroll_seed_str(void)
     // Also, don't use the shuffled seed as is, or we'll just end up with sequential seeds when
     // rolling multiple times.
     rng_shuffle_seed();
-    u32 new_seed = rng_get_u32();
+    u32 new_seed = rng_get_u32(RNG_TYPE_MISC);
     rng_set_seed(new_seed);
     u32_to_base36(new_seed, s_seed_str);
     update_seed_text();

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -918,8 +918,6 @@ static inline void reroll_seed_str(void)
     // Also, don't use the shuffled seed as is, or we'll just end up with sequential seeds when
     // rolling multiple times.
     rng_shuffle_seed();
-    u32 new_seed = rng_get_u32(RNG_TYPE_MISC);
-    rng_set_seed(new_seed);
     u32_to_base36(g_game_vars.rng_info.seed, s_seed_str);
     update_seed_text();
     s_seed_cursor_pos = BASE36_MAX_DIGITS;
@@ -1191,8 +1189,9 @@ static void seed_on_pressed(void)
  */
 static void play_on_pressed(void)
 {
-    // Apply provided Seed if enabled
-    if (use_seed)
+    // Apply provided Seed if enabled, and if we entered one. This prevents us from always using
+    // seed "ZZZZZZ" if we enter the Seed menu and hit Play without typing anything.
+    if (use_seed && strlen(s_seed_str) > 0)
         rng_set_seed(base36_to_u32(s_seed_str));
     else
         rng_shuffle_seed();

--- a/source/game/run_setup.c
+++ b/source/game/run_setup.c
@@ -920,7 +920,7 @@ static inline void reroll_seed_str(void)
     rng_shuffle_seed();
     u32 new_seed = rng_get_u32(RNG_TYPE_MISC);
     rng_set_seed(new_seed);
-    u32_to_base36(new_seed, s_seed_str);
+    u32_to_base36(g_game_vars.rng_info.seed, s_seed_str);
     update_seed_text();
     s_seed_cursor_pos = BASE36_MAX_DIGITS;
 }

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -237,7 +237,7 @@ void game_shop_on_init(void)
 static Item* game_shop_create_top_row_item(void)
 {
     // TODO: Randomize item type when consumables are implemented
-    return item_roll_new(ITEM_TYPE_JOKER);
+    return item_roll_new(ITEM_TYPE_JOKER, RNG_SEQ_SHOP_ITEMS);
 }
 
 /**

--- a/source/item.c
+++ b/source/item.c
@@ -6,7 +6,7 @@
 
 #include <tonc.h>
 
-Item* item_roll_new(enum ItemType item_type)
+Item* item_roll_new(enum ItemType item_type, enum RngSequence key)
 {
     if ((int)item_type < 0 || item_type >= ITEM_NUM_TYPES)
     {
@@ -18,7 +18,7 @@ Item* item_roll_new(enum ItemType item_type)
     GBAL_RETURN_IF_NULL_RET(item_funcs, NULL);
     GBAL_RETURN_IF_NULL_RET(item_funcs->roll_new, NULL);
 
-    return item_funcs->roll_new();
+    return item_funcs->roll_new(key);
 }
 
 int item_get_buy_price(Item* item)

--- a/source/item_funcs.c
+++ b/source/item_funcs.c
@@ -6,7 +6,7 @@
 #include "joker.h"
 #include "util.h"
 
-static Item* item_roll_new_unimplemented();
+static Item* item_roll_new_unimplemented(enum RngSequence key);
 static void item_acquire_unimplemented(Item* item);
 static bool item_always_can_acquire(Item* item);
 
@@ -47,7 +47,7 @@ ItemFuncs* get_item_type_funcs(enum ItemType type)
     return &item_func_table[type];
 }
 
-static Item* item_roll_new_unimplemented()
+static Item* item_roll_new_unimplemented(enum RngSequence key)
 {
     MGBA_FUNC_ERROR("Unimplemented roll_new function called");
     return NULL;

--- a/source/joker.c
+++ b/source/joker.c
@@ -360,7 +360,7 @@ static int joker_roll_id(void)
     int joker_rarity = joker_get_random_rarity();
 
     int matching_joker_ids[jokers_avail_size];
-    int fallback_random_idx = rng_get_u32() % jokers_avail_size;
+    int fallback_random_idx = rng_get_u32(RNG_TYPE_SHOP_ITEMS) % jokers_avail_size;
     int fallback_random_joker_id = UNDEFINED;
     int match_count = 0;
 
@@ -379,8 +379,9 @@ static int joker_roll_id(void)
         }
     }
 
-    int selected_joker_id = (match_count > 0) ? matching_joker_ids[rng_get_u32() % match_count]
-                                              : fallback_random_joker_id;
+    int selected_joker_id = (match_count > 0)
+                              ? matching_joker_ids[rng_get_u32(RNG_TYPE_SHOP_ITEMS) % match_count]
+                              : fallback_random_joker_id;
 
     return selected_joker_id;
 }
@@ -538,7 +539,7 @@ Sprite* joker_object_get_sprite(JokerObject* joker_object)
 int joker_get_random_rarity()
 {
     int joker_rarity = 0;
-    int rarity_roll = rng_get_u32() % 100;
+    int rarity_roll = rng_get_u32(RNG_TYPE_SHOP_ITEMS) % 100;
     if (rarity_roll < COMMON_JOKER_CHANCE)
     {
         joker_rarity = COMMON_JOKER;

--- a/source/joker.c
+++ b/source/joker.c
@@ -348,7 +348,7 @@ void joker_reset_rollable_jokers(void)
 /**
  * @brief Rolls a random Joker among the available ones
  */
-static int joker_roll_id(void)
+static int joker_roll_id(enum RngSequence key)
 {
     // Now determine how many jokers are available based on the rarity
     int jokers_avail_size = get_num_rollable_jokers();
@@ -360,7 +360,7 @@ static int joker_roll_id(void)
     int joker_rarity = joker_get_random_rarity();
 
     int matching_joker_ids[jokers_avail_size];
-    int fallback_random_idx = rng_get_u32(RNG_TYPE_SHOP_ITEMS) % jokers_avail_size;
+    int fallback_random_idx = rng_get_u32(key) % jokers_avail_size;
     int fallback_random_joker_id = UNDEFINED;
     int match_count = 0;
 
@@ -379,14 +379,13 @@ static int joker_roll_id(void)
         }
     }
 
-    int selected_joker_id = (match_count > 0)
-                              ? matching_joker_ids[rng_get_u32(RNG_TYPE_SHOP_ITEMS) % match_count]
-                              : fallback_random_joker_id;
+    int selected_joker_id = (match_count > 0) ? matching_joker_ids[rng_get_u32(key) % match_count]
+                                              : fallback_random_joker_id;
 
     return selected_joker_id;
 }
 
-Item* joker_object_roll_new(void)
+Item* joker_object_roll_new(enum RngSequence key)
 {
     if (no_rollable_jokers())
         return NULL;
@@ -407,7 +406,7 @@ Item* joker_object_roll_new(void)
     else
 #endif
     {
-        joker_id = joker_roll_id();
+        joker_id = joker_roll_id(key);
     }
 
     // If for some reason only no joker is left, don't make another
@@ -539,7 +538,7 @@ Sprite* joker_object_get_sprite(JokerObject* joker_object)
 int joker_get_random_rarity()
 {
     int joker_rarity = 0;
-    int rarity_roll = rng_get_u32(RNG_TYPE_SHOP_ITEMS) % 100;
+    int rarity_roll = rng_get_u32(RNG_SEQ_SHOP_ITEMS) % 100;
     if (rarity_roll < COMMON_JOKER_CHANCE)
     {
         joker_rarity = COMMON_JOKER;

--- a/source/joker.c
+++ b/source/joker.c
@@ -346,6 +346,37 @@ void joker_reset_rollable_jokers(void)
 }
 
 /**
+ * @brief Get a random rarity a Joker will be rolled from
+ *
+ * @param key to the RNG sequence used
+ * @return a random Joker rarity
+ */
+static inline int joker_get_random_rarity(enum RngSequence key)
+{
+    int joker_rarity = 0;
+    int rarity_roll = rng_get_u32(key) % 100;
+    if (rarity_roll < COMMON_JOKER_CHANCE)
+    {
+        joker_rarity = COMMON_JOKER;
+    }
+    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE)
+    {
+        joker_rarity = UNCOMMON_JOKER;
+    }
+    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE)
+    {
+        joker_rarity = RARE_JOKER;
+    }
+    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE +
+                               LEGENDARY_JOKER_CHANCE)
+    {
+        joker_rarity = LEGENDARY_JOKER;
+    }
+
+    return joker_rarity;
+}
+
+/**
  * @brief Rolls a random Joker among the available ones
  */
 static int joker_roll_id(enum RngSequence key)
@@ -357,7 +388,7 @@ static int joker_roll_id(enum RngSequence key)
         return UNDEFINED;
 
     // Roll for what rarity the joker will be
-    int joker_rarity = joker_get_random_rarity();
+    int joker_rarity = joker_get_random_rarity(key);
 
     int matching_joker_ids[jokers_avail_size];
     int fallback_random_idx = rng_get_u32(key) % jokers_avail_size;
@@ -533,31 +564,6 @@ Sprite* joker_object_get_sprite(JokerObject* joker_object)
     if (joker_object == NULL)
         return NULL;
     return sprite_object_get_sprite((SpriteObject*)joker_object);
-}
-
-int joker_get_random_rarity()
-{
-    int joker_rarity = 0;
-    int rarity_roll = rng_get_u32(RNG_SEQ_SHOP_ITEMS) % 100;
-    if (rarity_roll < COMMON_JOKER_CHANCE)
-    {
-        joker_rarity = COMMON_JOKER;
-    }
-    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE)
-    {
-        joker_rarity = UNCOMMON_JOKER;
-    }
-    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE)
-    {
-        joker_rarity = RARE_JOKER;
-    }
-    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE +
-                               LEGENDARY_JOKER_CHANCE)
-    {
-        joker_rarity = LEGENDARY_JOKER;
-    }
-
-    return joker_rarity;
 }
 
 static int s_get_num_spritesheets()

--- a/source/joker.c
+++ b/source/joker.c
@@ -113,7 +113,7 @@ static void s_joker_pb_remove_sprite_user(int pb);
 static int s_joker_pb_get_num_sprite_users(int joker_pb);
 static int s_get_unused_joker_pb(void);
 static int s_allocate_pb_if_needed(u8 joker_id);
-static int s_joker_get_random_rarity(enum RngSequence key);
+static int joker_get_random_rarity(enum RngSequence key);
 
 void joker_init()
 {
@@ -358,7 +358,7 @@ static int joker_roll_id(enum RngSequence key)
         return UNDEFINED;
 
     // Roll for what rarity the joker will be
-    int joker_rarity = s_joker_get_random_rarity(key);
+    int joker_rarity = joker_get_random_rarity(key);
 
     int matching_joker_ids[jokers_avail_size];
     int fallback_random_idx = rng_get_u32(key) % jokers_avail_size;
@@ -425,7 +425,7 @@ Item* joker_object_roll_new(enum RngSequence key)
  * @param key to the RNG sequence used
  * @return a random Joker rarity
  */
-static inline int s_joker_get_random_rarity(enum RngSequence key)
+static inline int joker_get_random_rarity(enum RngSequence key)
 {
     int joker_rarity = 0;
     int rarity_roll = rng_get_u32(key) % 100;

--- a/source/joker.c
+++ b/source/joker.c
@@ -113,6 +113,7 @@ static void s_joker_pb_remove_sprite_user(int pb);
 static int s_joker_pb_get_num_sprite_users(int joker_pb);
 static int s_get_unused_joker_pb(void);
 static int s_allocate_pb_if_needed(u8 joker_id);
+static int s_joker_get_random_rarity(enum RngSequence key);
 
 void joker_init()
 {
@@ -346,37 +347,6 @@ void joker_reset_rollable_jokers(void)
 }
 
 /**
- * @brief Get a random rarity a Joker will be rolled from
- *
- * @param key to the RNG sequence used
- * @return a random Joker rarity
- */
-static inline int joker_get_random_rarity(enum RngSequence key)
-{
-    int joker_rarity = 0;
-    int rarity_roll = rng_get_u32(key) % 100;
-    if (rarity_roll < COMMON_JOKER_CHANCE)
-    {
-        joker_rarity = COMMON_JOKER;
-    }
-    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE)
-    {
-        joker_rarity = UNCOMMON_JOKER;
-    }
-    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE)
-    {
-        joker_rarity = RARE_JOKER;
-    }
-    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE +
-                               LEGENDARY_JOKER_CHANCE)
-    {
-        joker_rarity = LEGENDARY_JOKER;
-    }
-
-    return joker_rarity;
-}
-
-/**
  * @brief Rolls a random Joker among the available ones
  */
 static int joker_roll_id(enum RngSequence key)
@@ -388,7 +358,7 @@ static int joker_roll_id(enum RngSequence key)
         return UNDEFINED;
 
     // Roll for what rarity the joker will be
-    int joker_rarity = joker_get_random_rarity(key);
+    int joker_rarity = s_joker_get_random_rarity(key);
 
     int matching_joker_ids[jokers_avail_size];
     int fallback_random_idx = rng_get_u32(key) % jokers_avail_size;
@@ -447,6 +417,37 @@ Item* joker_object_roll_new(enum RngSequence key)
     joker_set_rollable(joker_id, false);
 
     return (Item*)joker_object_new(joker_new(joker_id));
+}
+
+/**
+ * @brief Get a random rarity a Joker will be rolled from
+ *
+ * @param key to the RNG sequence used
+ * @return a random Joker rarity
+ */
+static inline int s_joker_get_random_rarity(enum RngSequence key)
+{
+    int joker_rarity = 0;
+    int rarity_roll = rng_get_u32(key) % 100;
+    if (rarity_roll < COMMON_JOKER_CHANCE)
+    {
+        joker_rarity = COMMON_JOKER;
+    }
+    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE)
+    {
+        joker_rarity = UNCOMMON_JOKER;
+    }
+    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE)
+    {
+        joker_rarity = RARE_JOKER;
+    }
+    else if (rarity_roll < COMMON_JOKER_CHANCE + UNCOMMON_JOKER_CHANCE + RARE_JOKER_CHANCE +
+                               LEGENDARY_JOKER_CHANCE)
+    {
+        joker_rarity = LEGENDARY_JOKER;
+    }
+
+    return joker_rarity;
 }
 
 static void set_and_shift_text(char* str, int* cursor_pos_x, int* cursor_pos_y, int color_pb)

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -1090,7 +1090,7 @@ static u32 misprint_joker_effect(
 
     *joker_effect = &s_shared_joker_effect;
 
-    (*joker_effect)->mult = rng_get_u32() % (MISPRINT_MAX_MULT + 1);
+    (*joker_effect)->mult = rng_get_u32(RNG_TYPE_JOKER_EFFECTS) % (MISPRINT_MAX_MULT + 1);
 
     return JOKER_EFFECT_FLAG_MULT;
 }
@@ -1301,7 +1301,7 @@ static u32 reserved_parking_joker_effect(
 
     u32 effect_flags_ret = JOKER_EFFECT_FLAG_NONE;
 
-    if ((rng_get_u32() % 2 == 0) && card_is_face(scored_card))
+    if ((rng_get_u32(RNG_TYPE_JOKER_EFFECTS) % 2 == 0) && card_is_face(scored_card))
     {
         *joker_effect = &s_shared_joker_effect;
 
@@ -1323,7 +1323,7 @@ static u32 business_card_joker_effect(
 
     u32 effect_flags_ret = JOKER_EFFECT_FLAG_NONE;
 
-    if ((rng_get_u32() % 2 == 0) && card_is_face(scored_card))
+    if ((rng_get_u32(RNG_TYPE_JOKER_EFFECTS) % 2 == 0) && card_is_face(scored_card))
     {
         *joker_effect = &s_shared_joker_effect;
 

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -1090,7 +1090,7 @@ static u32 misprint_joker_effect(
 
     *joker_effect = &s_shared_joker_effect;
 
-    (*joker_effect)->mult = rng_get_u32(RNG_TYPE_JOKER_EFFECTS) % (MISPRINT_MAX_MULT + 1);
+    (*joker_effect)->mult = rng_get_u32(RNG_SEQ_JOKER_MISPRINT) % (MISPRINT_MAX_MULT + 1);
 
     return JOKER_EFFECT_FLAG_MULT;
 }
@@ -1301,7 +1301,7 @@ static u32 reserved_parking_joker_effect(
 
     u32 effect_flags_ret = JOKER_EFFECT_FLAG_NONE;
 
-    if ((rng_get_u32(RNG_TYPE_JOKER_EFFECTS) % 2 == 0) && card_is_face(scored_card))
+    if (card_is_face(scored_card) && (rng_get_u32(RNG_SEQ_JOKER_RESERVED_PARKING) % 2 == 0))
     {
         *joker_effect = &s_shared_joker_effect;
 
@@ -1323,7 +1323,7 @@ static u32 business_card_joker_effect(
 
     u32 effect_flags_ret = JOKER_EFFECT_FLAG_NONE;
 
-    if ((rng_get_u32(RNG_TYPE_JOKER_EFFECTS) % 2 == 0) && card_is_face(scored_card))
+    if (card_is_face(scored_card) && (rng_get_u32(RNG_SEQ_JOKER_BUSINESS_CARD) % 2 == 0))
     {
         *joker_effect = &s_shared_joker_effect;
 

--- a/source/random.c
+++ b/source/random.c
@@ -23,9 +23,17 @@ void rng_update(void)
 
 void rng_set_seed(u32 seed)
 {
-    g_game_vars.rng_info.seed = seed % (MAX_BASE36 + 1);
-    g_game_vars.rng_info.step = 0;
+    // We store the seed to display it at the end of the run, but here it's only used to generate
+    // the independent rng sequences' initial states. We also avoid the seed 0 as the Xorshift32
+    // method used will stay stuck.
+    g_game_vars.rng_info.seed = (seed == 0 ? MAX_BASE36 : seed) % (MAX_BASE36 + 1);
     srand(g_game_vars.rng_info.seed);
+
+    // Generate rng states for all RngTypes categories using the given seed
+    for (enum RngType type = 0; type < RNG_TYPE_MAX; type++)
+    {
+        g_game_vars.rng_info.states[type] = rand();
+    }
 }
 
 void rng_shuffle_seed(void)
@@ -33,19 +41,19 @@ void rng_shuffle_seed(void)
     rng_set_seed(s_timer_acc);
 }
 
-u32 rng_get_u32(void)
+u32 rng_get_u32(enum RngType type)
 {
-    g_game_vars.rng_info.step++;
-    return rand();
+    // Xorshift32
+    uint32_t old_state = g_game_vars.rng_info.states[type];
+    old_state ^= old_state << 13;
+    old_state ^= old_state >> 17;
+    old_state ^= old_state << 5;
+
+    g_game_vars.rng_info.states[type] = old_state;
+    return old_state;
 }
 
 void rng_restore(RngInfo info)
 {
     g_game_vars.rng_info = info;
-
-    srand(g_game_vars.rng_info.seed);
-    for (u32 i = 0; i < g_game_vars.rng_info.step; i++)
-    {
-        (void)rng_get_u32();
-    }
 }

--- a/source/random.c
+++ b/source/random.c
@@ -24,6 +24,12 @@ void rng_update(void)
     s_timer_acc += (u32)REG_TM1D;
 }
 
+void rng_shuffle_seed(void)
+{
+    srand(s_timer_acc);
+    rng_set_seed(rand());
+}
+
 void rng_set_seed(u32 seed)
 {
     // We store the seed to display it at the end of the run, but here it's only used to generate
@@ -45,12 +51,6 @@ static inline void s_init_rng_states(void)
     {
         g_game_vars.rng_info.states[key] = rand();
     }
-}
-
-void rng_shuffle_seed(void)
-{
-    srand(s_timer_acc);
-    rng_set_seed(rand());
 }
 
 u32 rng_get_u32(enum RngSequence key)

--- a/source/random.c
+++ b/source/random.c
@@ -26,7 +26,8 @@ void rng_set_seed(u32 seed)
     // We store the seed to display it at the end of the run, but here it's only used to generate
     // the independent rng sequences' initial states. We also avoid the seed 0 as the Xorshift32
     // method used will stay stuck.
-    g_game_vars.rng_info.seed = (seed == 0 ? MAX_BASE36 : seed) % (MAX_BASE36 + 1);
+    u32 capped_seed = seed % (MAX_BASE36 + 1);
+    g_game_vars.rng_info.seed = (capped_seed == 0) ? MAX_BASE36 : capped_seed;
     srand(g_game_vars.rng_info.seed);
 
     // Generate rng states for all RngTypes categories using the given seed

--- a/source/random.c
+++ b/source/random.c
@@ -23,7 +23,7 @@ void rng_update(void)
 
 /**
  * @brief Reset all independent RNG sequences to their initial states using the
- *         provided custom seed.
+ *         global custom seed.
  */
 static void init_rng_states(void)
 {

--- a/source/random.c
+++ b/source/random.c
@@ -21,6 +21,19 @@ void rng_update(void)
     s_timer_acc += (u32)REG_TM1D;
 }
 
+/**
+ * @brief Reset all independent RNG sequences to their initial states using the
+ *         provided custom seed.
+ */
+static void init_rng_states(void)
+{
+    srand(g_game_vars.rng_info.seed);
+    for (enum RngSequence key = 0; key < RNG_SEQ_MAX; key++)
+    {
+        g_game_vars.rng_info.states[key] = rand();
+    }
+}
+
 void rng_set_seed(u32 seed)
 {
     // We store the seed to display it at the end of the run, but here it's only used to generate
@@ -28,30 +41,34 @@ void rng_set_seed(u32 seed)
     // method used will stay stuck.
     u32 capped_seed = seed % (MAX_BASE36 + 1);
     g_game_vars.rng_info.seed = (capped_seed == 0) ? MAX_BASE36 : capped_seed;
-    srand(g_game_vars.rng_info.seed);
-
-    // Generate rng states for all RngTypes categories using the given seed
-    for (enum RngType type = 0; type < RNG_TYPE_MAX; type++)
-    {
-        g_game_vars.rng_info.states[type] = rand();
-    }
+    init_rng_states();
 }
 
 void rng_shuffle_seed(void)
 {
-    rng_set_seed(s_timer_acc);
+    srand(s_timer_acc);
+    rng_set_seed(rand());
 }
 
-u32 rng_get_u32(enum RngType type)
+/**
+ * @brief Transforms a given RNG state according to the Xorshift32 algorithm.
+ *
+ * Custom RNG had to be implemented to be able to manage several independent sequences, since
+ * `initstate` and `setstate` are POSIX and not available on GBA via devkitpro.
+ *
+ * @param state pointer to a 32-bit RNG state
+ */
+static inline void xorshift32(u32* state)
 {
-    // Xorshift32
-    uint32_t old_state = g_game_vars.rng_info.states[type];
-    old_state ^= old_state << 13;
-    old_state ^= old_state >> 17;
-    old_state ^= old_state << 5;
+    *(state) ^= *(state) << 13;
+    *(state) ^= *(state) >> 17;
+    *(state) ^= *(state) << 5;
+}
 
-    g_game_vars.rng_info.states[type] = old_state;
-    return old_state;
+u32 rng_get_u32(enum RngSequence key)
+{
+    xorshift32(&g_game_vars.rng_info.states[key]);
+    return g_game_vars.rng_info.states[key];
 }
 
 void rng_restore(RngInfo info)

--- a/source/random.c
+++ b/source/random.c
@@ -6,6 +6,9 @@
 #include <stdlib.h>
 #include <tonc.h>
 
+static void s_init_rng_states(void);
+static void s_xorshift32(u32* state);
+
 // Accumulate timer 1 into a bigger variable so we can generate more diverse seeds
 static u32 s_timer_acc = 0;
 
@@ -21,11 +24,21 @@ void rng_update(void)
     s_timer_acc += (u32)REG_TM1D;
 }
 
+void rng_set_seed(u32 seed)
+{
+    // We store the seed to display it at the end of the run, but here it's only used to generate
+    // the independent rng sequences' initial states. We also avoid the seed 0 as the Xorshift32
+    // method used will stay stuck.
+    u32 capped_seed = seed % (MAX_BASE36 + 1);
+    g_game_vars.rng_info.seed = (capped_seed == 0) ? MAX_BASE36 : capped_seed;
+    s_init_rng_states();
+}
+
 /**
  * @brief Reset all independent RNG sequences to their initial states using the
  *         global custom seed.
  */
-static void init_rng_states(void)
+static inline void s_init_rng_states(void)
 {
     srand(g_game_vars.rng_info.seed);
     for (enum RngSequence key = 0; key < RNG_SEQ_MAX; key++)
@@ -34,20 +47,16 @@ static void init_rng_states(void)
     }
 }
 
-void rng_set_seed(u32 seed)
-{
-    // We store the seed to display it at the end of the run, but here it's only used to generate
-    // the independent rng sequences' initial states. We also avoid the seed 0 as the Xorshift32
-    // method used will stay stuck.
-    u32 capped_seed = seed % (MAX_BASE36 + 1);
-    g_game_vars.rng_info.seed = (capped_seed == 0) ? MAX_BASE36 : capped_seed;
-    init_rng_states();
-}
-
 void rng_shuffle_seed(void)
 {
     srand(s_timer_acc);
     rng_set_seed(rand());
+}
+
+u32 rng_get_u32(enum RngSequence key)
+{
+    s_xorshift32(&g_game_vars.rng_info.states[key]);
+    return g_game_vars.rng_info.states[key];
 }
 
 /**
@@ -58,17 +67,11 @@ void rng_shuffle_seed(void)
  *
  * @param state pointer to a 32-bit RNG state
  */
-static inline void xorshift32(u32* state)
+static inline void s_xorshift32(u32* state)
 {
     *(state) ^= *(state) << 13;
     *(state) ^= *(state) >> 17;
     *(state) ^= *(state) << 5;
-}
-
-u32 rng_get_u32(enum RngSequence key)
-{
-    xorshift32(&g_game_vars.rng_info.states[key]);
-    return g_game_vars.rng_info.states[key];
 }
 
 void rng_restore(RngInfo info)

--- a/source/save.c
+++ b/source/save.c
@@ -178,7 +178,7 @@ typedef struct SaveGame
 static const SaveGame SaveGame_default = {
     .tag_internal = "-INTERNAL DATA -",
     .timer = 0,
-    .rng_info = {0, 0},
+    .rng_info = {0, {0}},
     .round = 0,
     .ante = 0,
     .money = 0,

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -347,7 +347,7 @@ void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 
     play_sfx(
         SFX_CARD_FOCUS,
-        MM_BASE_PITCH_RATE + rng_get_u32() % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
+        MM_BASE_PITCH_RATE + rng_get_u32(RNG_TYPE_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
         SFX_DEFAULT_VOLUME
     );
     sprite_object->ty = sprite_object->ty + int2fx((focus ? -1 : 1) * SPRITE_FOCUS_RAISE_PX);

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -347,7 +347,7 @@ void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 
     play_sfx(
         SFX_CARD_FOCUS,
-        MM_BASE_PITCH_RATE + rng_get_u32(RNG_TYPE_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
+        MM_BASE_PITCH_RATE + rng_get_u32(RNG_SEQ_MISC) % CARD_FOCUS_SFX_PITCH_OFFSET_RANGE,
         SFX_DEFAULT_VOLUME
     );
     sprite_object->ty = sprite_object->ty + int2fx((focus ? -1 : 1) * SPRITE_FOCUS_RAISE_PX);


### PR DESCRIPTION
Closes #588

I replaced almost all calls to the glibc's RNG to use my own so that we can easily manage several, independent RNG sequences. The default RNG is only used when resetting the seed: we call `srand` on it, and generate the starting states of our RNG using `rand`.

Also, if we could wait for the Skip Tags to be merged before merging this It would be great, I'd rather rebase this on main than the skip tags ><'