### PR TITLE
Refactored error checking macros with newly added generic assert-style macros

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -14,39 +14,7 @@
 #include "mgba_logger.h"
 #include "random.h"
 #include "sprite.h"
-
-// TODO: Merge these with GBAL_RETURN_IF_NULL macros?
-/**
- * @brief Checks if @p item is of type @p expected_type - logs error message and returns otherwise
- *
- *  This version is for a function that returns a value, while
- *  @ref ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID is for a void function.
- */
-#define ITEM_RETURN_IF_UNEXPECTED_TYPE_RET(item, expected_type, ret_val)         \
-    do                                                                           \
-    {                                                                            \
-        if ((item)->type != expected_type)                                       \
-        {                                                                        \
-            MGBA_FUNC_ERROR("Unexpected %s->type != %s", #item, #expected_type); \
-            return (ret_val);                                                    \
-        }                                                                        \
-    } while (0)
-
-/**
- * @brief Checks if @p item is of type @p expected_type - logs error message and returns otherwise
- *
- * This version is for a void function, while @ref ITEM_RETURN_IF_UNEXPECTED_TYPE_RET is for one
- * with a return value.
- */
-#define ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(item, expected_type)                 \
-    do                                                                           \
-    {                                                                            \
-        if ((item)->type != expected_type)                                       \
-        {                                                                        \
-            MGBA_FUNC_ERROR("Unexpected %s->type != %s", #item, #expected_type); \
-            return;                                                              \
-        }                                                                        \
-    } while (0)
+#include "util.h"
 
 enum ItemType
 {

--- a/include/item.h
+++ b/include/item.h
@@ -14,7 +14,6 @@
 #include "mgba_logger.h"
 #include "random.h"
 #include "sprite.h"
-#include "util.h"
 
 enum ItemType
 {

--- a/include/util.h
+++ b/include/util.h
@@ -69,17 +69,6 @@
 // TODO: Document and clean documentation
 
 /**
- * @brief Returns and logs error @p message if @p expression is false.
- *
- * This version is for a void function, while @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS is
- * for one with a return value.
- *
- * See @ref GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
- */
-#define GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, message, ...) \
-    GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, , message, __VA_ARGS__)
-
-/**
  * @brief Returns @p ret_val and logs error @p message if @p expression is false.
  *
  * This version is for a function that returns a value,
@@ -87,7 +76,6 @@
  *
  * See @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
  */
-// TODO: Handle trailing comma
 #define GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
     do                                                                                   \
     {                                                                                    \
@@ -97,18 +85,6 @@
             return ret_val;                                                            \
         }                                                                                \
     } while (0)
-
-/**
- * @brief Returns and logs an error message if @p expression is false.
- *
- * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS is
- * for one with a return value.
- *
- * See @ref GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS for a version that allows passing
- * any custom error message.
- */
-#define GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(expression) \
-    GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, "Assert failed: %s", #expression)
 
 /**
  * @brief Returns @p ret_val and logs an error message if @p expression is false.
@@ -128,15 +104,6 @@
     )
 
 /**
- * @brief Checks if @p param is NULL, prints error message and returns in case it is.
- * Useful for checking arguments to a function or errors during control flow.
- *
- * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_NULL is for one with
- * a return value.
- */
-#define GBAL_VOID_FUNC_RETURN_IF_NULL(param) GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL)
-
-/**
  * @brief Returns @p ret_val and prints error message if @p param is equal to NULL.
  * Useful for checking arguments to a function or errors during control flow.
  * @param ret_val The value to return in case @p param is equal to NULL.
@@ -146,6 +113,13 @@
  */
 #define GBAL_RET_FUNC_RETURN_IF_NULL(param, ret_val) \
     GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL, ret_val)
+
+/**
+ * @brief An empty return value for RETURN_IF macros when used in void functions
+ * Expands to nothing because macros expand normally with blank arguments so it's more
+ * to show that the empty value is intended.
+ */
+#define RET_NONE
 
 /**
  * @brief Avoid overflow when adding two u32 integers

--- a/include/util.h
+++ b/include/util.h
@@ -68,49 +68,70 @@
 
 // TODO: Document and clean documentation
 
+/**
+ * @brief Returns and logs error @p message if @p expression is true.
+ *
+ * This version is for a void function, while @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS is
+ * for one with a return value.
+ *
+ * See @ref GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
+ */
 #define GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, message, ...) \
-   do                                                         \
-    {                                                          \
-        if (!(expression))                                   \
-        {                                                      \
-            LOG_ERROR(message, __VA_ARGS__); \
-            return;                                            \
-        }                                                      \
+    do                                                                           \
+    {                                                                            \
+        if (!(expression))                                                       \
+        {                                                                        \
+            LOG_ERROR(message, __VA_ARGS__);                                     \
+            return;                                                              \
+        }                                                                        \
     } while (0)
-
-#define GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
-   do                                                         \
-    {                                                          \
-        if (!(expression))                                   \
-        {                                                      \
-            LOG_ERROR(message, __VA_ARGS__); \
-            return (ret_val);                                            \
-        }                                                      \
-    } while (0)
-
-#define GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(expression) \
-    GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS( \
-        expression, \
-        "Assert failed: %s", \
-        #expression \
-    )
-
-#define GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(expression, ret_val) \
-    GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(                \
-        expression, \
-        ret_val, \
-        "Assert failed: %s", \
-        #expression \
-    ) \
 
 /**
- * @brief Checks if @p param is equal to @p value, prints error message and returns in case it is.
- * Useful for checking arguments to a function or errors during control flow.
+ * @brief Returns @p ret_val and logs error @p message if @p expression is true.
  *
- * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_ON_ERROR_VAL is for one with
- * a return value.
+ * This version is for a function that returns a value,
+ * while @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS is for a void function.
+ *
+ * See @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
  */
+#define GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
+    do                                                                                   \
+    {                                                                                    \
+        if (!(expression))                                                               \
+        {                                                                                \
+            LOG_ERROR(message, __VA_ARGS__);                                             \
+            return (ret_val);                                                            \
+        }                                                                                \
+    } while (0)
 
+/**
+ * @brief Returns and logs an error message if @p expression is true.
+ *
+ * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS is
+ * for one with a return value.
+ *
+ * See @ref GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS for a version that allows passing
+ * any custom error message.
+ */
+#define GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(expression) \
+    GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, "Assert failed: %s", #expression)
+
+/**
+ * @brief Returns @p ret_val and logs an error message if @p expression is true.
+ *
+ * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS is
+ * for one with a return value.
+ *
+ * See @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS for a version that allows passing
+ * any custom error message.
+ */
+#define GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(expression, ret_val) \
+    GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(                \
+        expression,                                               \
+        ret_val,                                                  \
+        "Assert failed: %s",                                      \
+        #expression                                               \
+    )
 
 /**
  * @brief Checks if @p param is NULL, prints error message and returns in case it is.
@@ -119,16 +140,14 @@
  * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_NULL is for one with
  * a return value.
  */
-#define GBAL_VOID_FUNC_RETURN_IF_NULL(param) \
-    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL)
+#define GBAL_VOID_FUNC_RETURN_IF_NULL(param) GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL)
 
 /**
- * @brief Checks if @p param is equal to NULL
- * and prints error message and returns in case it is.
+ * @brief Returns @p ret_val and prints error message if @p param is equal to NULL.
  * Useful for checking arguments to a function or errors during control flow.
  * @param ret_val The value to return in case @p param is equal to NULL.
  *
- * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
+ * This version is for a function that returns a value while @ref GBAL_VOID_FUNC_RETURN_IF_NULL
  * is for a void function.
  */
 #define GBAL_RET_FUNC_RETURN_IF_NULL(param, ret_val) \

--- a/include/util.h
+++ b/include/util.h
@@ -104,15 +104,6 @@
         }                                                                                \
     } while (0)
 
-
-if (!(expression))                                
-{                                                 
-    MGBA_FUNC_ERROR("Unexpected value %d", value);
-    return (ret_val);                             
-}
-
-GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, "Unexpected value %d", value);
-
 /**
  * @brief Returns and logs an error message if @p expression is false.
  *

--- a/include/util.h
+++ b/include/util.h
@@ -69,7 +69,7 @@
 // TODO: Document and clean documentation
 
 /**
- * @brief Returns and logs error @p message if @p expression is true.
+ * @brief Returns and logs error @p message if @p expression is false.
  *
  * This version is for a void function, while @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS is
  * for one with a return value.
@@ -87,7 +87,7 @@
     } while (0)
 
 /**
- * @brief Returns @p ret_val and logs error @p message if @p expression is true.
+ * @brief Returns @p ret_val and logs error @p message if @p expression is false.
  *
  * This version is for a function that returns a value,
  * while @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS is for a void function.
@@ -104,8 +104,17 @@
         }                                                                                \
     } while (0)
 
+
+if (!(expression))                                
+{                                                 
+    MGBA_FUNC_ERROR("Unexpected value %d", value);
+    return (ret_val);                             
+}
+
+GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, "Unexpected value %d", value);
+
 /**
- * @brief Returns and logs an error message if @p expression is true.
+ * @brief Returns and logs an error message if @p expression is false.
  *
  * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS is
  * for one with a return value.
@@ -117,7 +126,7 @@
     GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, "Assert failed: %s", #expression)
 
 /**
- * @brief Returns @p ret_val and logs an error message if @p expression is true.
+ * @brief Returns @p ret_val and logs an error message if @p expression is false.
  *
  * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS is
  * for one with a return value.

--- a/include/util.h
+++ b/include/util.h
@@ -71,9 +71,10 @@
 /**
  * @brief Returns @p ret_val and logs error @p message if @p expression is false.
  *
- * This version is for a function that returns a value,
- * while @ref GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS is for a void function.
+ * @param ret_val The value to return in case @p expression is false. 
+ * Pass @ref RET_NONE in a void function
  *
+ * @param message The message to log in @p expression is false.
  * See @ref GBAL_RETURN_IF_ASSERT_FAILS for a version with a default message
  */
 #define GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
@@ -89,8 +90,8 @@
 /**
  * @brief Returns @p ret_val and logs an error message if @p expression is false.
  *
- * This version is for a void function, while @ref GBAL_RETURN_IF_ASSERT_FAILS is
- * for one with a return value.
+ * @param ret_val The value to return in case @p expression is false. 
+ * Pass @ref RET_NONE in a void function
  *
  * See @ref GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS for a version that allows passing
  * any custom error message.
@@ -100,8 +101,10 @@
 
 /**
  * @brief Returns @p ret_val and prints error message if @p param is equal to NULL.
- * Useful for checking arguments to a function or errors during control flow.
- * @param ret_val The value to return in case @p param is equal to NULL.
+ * Useful for checking arguments or function return values during control flow.
+ * 
+ * @param ret_val The value to return in case @p param is equal to NULL. 
+ * Pass @ref RET_NONE in a void function
  *
  * This version is for a function that returns a value while @ref GBAL_VOID_FUNC_RETURN_IF_NULL
  * is for a void function.

--- a/include/util.h
+++ b/include/util.h
@@ -93,7 +93,7 @@
     {                                                                                    \
         if (!(expression))                                                               \
         {                                                                                \
-            LOG_ERROR(message, __VA_ARGS__);                                             \
+            LOG_ERROR(message __VA_OPT__(,) __VA_ARGS__);                                             \
             return ret_val;                                                            \
         }                                                                                \
     } while (0)

--- a/include/util.h
+++ b/include/util.h
@@ -77,14 +77,7 @@
  * See @ref GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
  */
 #define GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, message, ...) \
-    do                                                                           \
-    {                                                                            \
-        if (!(expression))                                                       \
-        {                                                                        \
-            LOG_ERROR(message, __VA_ARGS__);                                     \
-            return;                                                              \
-        }                                                                        \
-    } while (0)
+    GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, , message, __VA_ARGS__)
 
 /**
  * @brief Returns @p ret_val and logs error @p message if @p expression is false.
@@ -94,13 +87,14 @@
  *
  * See @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
  */
+// TODO: Handle trailing comma
 #define GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
     do                                                                                   \
     {                                                                                    \
         if (!(expression))                                                               \
         {                                                                                \
             LOG_ERROR(message, __VA_ARGS__);                                             \
-            return (ret_val);                                                            \
+            return ret_val;                                                            \
         }                                                                                \
     } while (0)
 

--- a/include/util.h
+++ b/include/util.h
@@ -72,36 +72,31 @@
  * @brief Returns @p ret_val and logs error @p message if @p expression is false.
  *
  * This version is for a function that returns a value,
- * while @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS is for a void function.
+ * while @ref GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS is for a void function.
  *
- * See @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS for a version with a default message
+ * See @ref GBAL_RETURN_IF_ASSERT_FAILS for a version with a default message
  */
-#define GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
-    do                                                                                   \
-    {                                                                                    \
-        if (!(expression))                                                               \
-        {                                                                                \
-            LOG_ERROR(message __VA_OPT__(,) __VA_ARGS__);                                             \
-            return ret_val;                                                            \
-        }                                                                                \
+#define GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
+    do                                                                          \
+    {                                                                           \
+        if (!(expression))                                                      \
+        {                                                                       \
+            LOG_ERROR(message __VA_OPT__(,) __VA_ARGS__);                       \
+            return ret_val;                                                     \
+        }                                                                       \
     } while (0)
 
 /**
  * @brief Returns @p ret_val and logs an error message if @p expression is false.
  *
- * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS is
+ * This version is for a void function, while @ref GBAL_RETURN_IF_ASSERT_FAILS is
  * for one with a return value.
  *
- * See @ref GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS for a version that allows passing
+ * See @ref GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS for a version that allows passing
  * any custom error message.
  */
-#define GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(expression, ret_val) \
-    GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(                \
-        expression,                                               \
-        ret_val,                                                  \
-        "Assert failed: %s",                                      \
-        #expression                                               \
-    )
+#define GBAL_RETURN_IF_ASSERT_FAILS(expression, ret_val) \
+    GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, "Assert failed: %s", #expression)
 
 /**
  * @brief Returns @p ret_val and prints error message if @p param is equal to NULL.
@@ -111,8 +106,8 @@
  * This version is for a function that returns a value while @ref GBAL_VOID_FUNC_RETURN_IF_NULL
  * is for a void function.
  */
-#define GBAL_RET_FUNC_RETURN_IF_NULL(param, ret_val) \
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL, ret_val)
+#define GBAL_RETURN_IF_NULL(param, ret_val) \
+    GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS((param) != NULL, ret_val, "Unexpected %s == NULL", #param)
 
 /**
  * @brief An empty return value for RETURN_IF macros when used in void functions

--- a/include/util.h
+++ b/include/util.h
@@ -66,38 +66,42 @@
 #define LOG_ERROR(...) ((void)(0))
 #endif
 
-#define GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(expression, message, ...) \
+// TODO: Document and clean documentation
+
+#define GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, message, ...) \
    do                                                         \
     {                                                          \
-        if ((expression))                                   \
+        if (!(expression))                                   \
         {                                                      \
             LOG_ERROR(message, __VA_ARGS__); \
             return;                                            \
         }                                                      \
     } while (0)
 
-#define GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
+#define GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
    do                                                         \
     {                                                          \
-        if ((expression))                                   \
+        if (!(expression))                                   \
         {                                                      \
             LOG_ERROR(message, __VA_ARGS__); \
             return (ret_val);                                            \
         }                                                      \
     } while (0)
 
-#define GBAL_VOID_FUNC_RETURN_IF_EQUALS_CUST_MSG(param, value, message, ...) \
-    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) == (value), message, __VA_ARGS__)
+#define GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(expression) \
+    GBAL_VOID_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS( \
+        expression, \
+        "Assert failed: %s", \
+        #expression \
+    )
 
-#define GBAL_RET_FUNC_RETURN_IF_EQUALS_CUST_MSG(param, value, ret_val, message, ...) \
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) == (value), ret_val, message, __VA_ARGS__)
-
-#define GBAL_VOID_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(param, value, message, ...) \
-    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) != (value), message, __VA_ARGS__)
-
-#define GBAL_RET_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(param, value, ret_val, message, ...) \
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) != (value), ret_val, message, __VA_ARGS__)
-
+#define GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(expression, ret_val) \
+    GBAL_RET_FUNC_CUST_MSG_RETURN_IF_ASSERT_FAILS(                \
+        expression, \
+        ret_val, \
+        "Assert failed: %s", \
+        #expression \
+    ) \
 
 /**
  * @brief Checks if @p param is equal to @p value, prints error message and returns in case it is.
@@ -106,43 +110,7 @@
  * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_ON_ERROR_VAL is for one with
  * a return value.
  */
-#define GBAL_VOID_FUNC_RETURN_IF_EQUALS(param, value)         \
-    GBAL_VOID_FUNC_RETURN_IF_EQUALS_CUST_MSG(                  \
-        param,  \
-        value, \
-        "Unexpected value: %s == %s", \
-        #param, \
-        #value \
-    )\
 
-#define GBAL_RET_FUNC_RETURN_IF_EQUALS(param, value, ret_val) \
-    GBAL_RET_FUNC_RETURN_IF_EQUALS_CUST_MSG(                  \
-        param,  \
-        value, \
-        ret_val, \
-        "Unexpected value: %s == %s", \
-        #param, \
-        #value \
-    )\
-
-#define GBAL_VOID_FUNC_RETURN_IF_UNEQUALS(param, value)         \
-    GBAL_VOID_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(                  \
-        param,  \
-        value, \
-        "Unexpected value: %s != %s", \
-        #param, \
-        #value \
-    )\
-
-#define GBAL_RET_FUNC_RETURN_IF_UNEQUALS(param, value, ret_val) \
-    GBAL_RET_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(                  \
-        param,  \
-        value, \
-        ret_val, \
-        "Unexpected value: %s != %s", \
-        #param, \
-        #value \
-    )\
 
 /**
  * @brief Checks if @p param is NULL, prints error message and returns in case it is.
@@ -151,7 +119,8 @@
  * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_NULL is for one with
  * a return value.
  */
-#define GBAL_VOID_FUNC_RETURN_IF_NULL(param) GBAL_VOID_FUNC_RETURN_IF_EQUALS(param, NULL)
+#define GBAL_VOID_FUNC_RETURN_IF_NULL(param) \
+    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL)
 
 /**
  * @brief Checks if @p param is equal to NULL
@@ -162,15 +131,8 @@
  * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */
-#define GBAL_RET_FUNC_RETURN_IF_NULL(param, ret_val)           \
-    do                                                         \
-    {                                                          \
-        if ((param) == NULL)                                   \
-        {                                                      \
-            LOG_ERROR("Unexpected value: %s == NULL", #param); \
-            return (ret_val);                                  \
-        }                                                      \
-    } while (0)
+#define GBAL_RET_FUNC_RETURN_IF_NULL(param, ret_val) \
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) != NULL, ret_val)
 
 /**
  * @brief Avoid overflow when adding two u32 integers

--- a/include/util.h
+++ b/include/util.h
@@ -66,22 +66,92 @@
 #define LOG_ERROR(...) ((void)(0))
 #endif
 
-/**
- * @brief Checks if @p param is NULL and prints error message and returns in case it is.
- * Useful for checking arguments to a function or errors during control flow.
- *
- * This version is for a void function, while @ref GBAL_RETURN_ON_ERROR_VAL_RET is for one with
- * a return value.
- */
-#define GBAL_RETURN_IF_NULL_VOID(param)                        \
-    do                                                         \
+#define GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(expression, message, ...) \
+   do                                                         \
     {                                                          \
-        if ((param) == NULL)                                   \
+        if ((expression))                                   \
         {                                                      \
-            LOG_ERROR("Unexpected value: %s == NULL", #param); \
+            LOG_ERROR(message, __VA_ARGS__); \
             return;                                            \
         }                                                      \
     } while (0)
+
+#define GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(expression, ret_val, message, ...) \
+   do                                                         \
+    {                                                          \
+        if ((expression))                                   \
+        {                                                      \
+            LOG_ERROR(message, __VA_ARGS__); \
+            return (ret_val);                                            \
+        }                                                      \
+    } while (0)
+
+#define GBAL_VOID_FUNC_RETURN_IF_EQUALS_CUST_MSG(param, value, message, ...) \
+    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) == (value), message, __VA_ARGS__)
+
+#define GBAL_RET_FUNC_RETURN_IF_EQUALS_CUST_MSG(param, value, ret_val, message, ...) \
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) == (value), ret_val, message, __VA_ARGS__)
+
+#define GBAL_VOID_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(param, value, message, ...) \
+    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((param) != (value), message, __VA_ARGS__)
+
+#define GBAL_RET_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(param, value, ret_val, message, ...) \
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((param) != (value), ret_val, message, __VA_ARGS__)
+
+
+/**
+ * @brief Checks if @p param is equal to @p value, prints error message and returns in case it is.
+ * Useful for checking arguments to a function or errors during control flow.
+ *
+ * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_ON_ERROR_VAL is for one with
+ * a return value.
+ */
+#define GBAL_VOID_FUNC_RETURN_IF_EQUALS(param, value)         \
+    GBAL_VOID_FUNC_RETURN_IF_EQUALS_CUST_MSG(                  \
+        param,  \
+        value, \
+        "Unexpected value: %s == %s", \
+        #param, \
+        #value \
+    )\
+
+#define GBAL_RET_FUNC_RETURN_IF_EQUALS(param, value, ret_val) \
+    GBAL_RET_FUNC_RETURN_IF_EQUALS_CUST_MSG(                  \
+        param,  \
+        value, \
+        ret_val, \
+        "Unexpected value: %s == %s", \
+        #param, \
+        #value \
+    )\
+
+#define GBAL_VOID_FUNC_RETURN_IF_UNEQUALS(param, value)         \
+    GBAL_VOID_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(                  \
+        param,  \
+        value, \
+        "Unexpected value: %s != %s", \
+        #param, \
+        #value \
+    )\
+
+#define GBAL_RET_FUNC_RETURN_IF_UNEQUALS(param, value, ret_val) \
+    GBAL_RET_FUNC_RETURN_IF_UNEQUALS_CUST_MSG(                  \
+        param,  \
+        value, \
+        ret_val, \
+        "Unexpected value: %s != %s", \
+        #param, \
+        #value \
+    )\
+
+/**
+ * @brief Checks if @p param is NULL, prints error message and returns in case it is.
+ * Useful for checking arguments to a function or errors during control flow.
+ *
+ * This version is for a void function, while @ref GBAL_RET_FUNC_RETURN_IF_NULL is for one with
+ * a return value.
+ */
+#define GBAL_VOID_FUNC_RETURN_IF_NULL(param) GBAL_VOID_FUNC_RETURN_IF_EQUALS(param, NULL)
 
 /**
  * @brief Checks if @p param is equal to NULL
@@ -92,7 +162,7 @@
  * This version is for a function that returns a value while @ref GBAL_RETURN_ON_ERROR_VAL_VOID
  * is for a void function.
  */
-#define GBAL_RETURN_IF_NULL_RET(param, ret_val)                \
+#define GBAL_RET_FUNC_RETURN_IF_NULL(param, ret_val)           \
     do                                                         \
     {                                                          \
         if ((param) == NULL)                                   \

--- a/source/card.c
+++ b/source/card.c
@@ -186,7 +186,7 @@ Sprite* card_object_get_sprite(CardObject* card_object)
 
 int card_object_get_buy_price(Item* card_object)
 {
-    GBAL_RETURN_IF_NULL_RET(card_object, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(card_object, UNDEFINED);
     ITEM_RETURN_IF_UNEXPECTED_TYPE_RET(card_object, ITEM_TYPE_PLAYING_CARD, UNDEFINED);
 
     return 1;
@@ -194,8 +194,8 @@ int card_object_get_buy_price(Item* card_object)
 
 void card_object_dispose(Item** card_object_item)
 {
-    GBAL_RETURN_IF_NULL_VOID(card_object_item);
-    GBAL_RETURN_IF_NULL_VOID(*card_object_item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(card_object_item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(*card_object_item);
     ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(*card_object_item, ITEM_TYPE_PLAYING_CARD);
 
     CardObject* card_object = (CardObject*)(*card_object_item);

--- a/source/card.c
+++ b/source/card.c
@@ -194,9 +194,12 @@ int card_object_get_buy_price(Item* card_object)
 
 void card_object_dispose(Item** card_object_item)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(card_object_item);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(*card_object_item);
-    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((*card_object_item)->type == ITEM_TYPE_PLAYING_CARD);
+    GBAL_RET_FUNC_RETURN_IF_NULL(card_object_item, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_NULL(*card_object_item, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(
+        (*card_object_item)->type == ITEM_TYPE_PLAYING_CARD,
+        RET_NONE
+    );
 
     CardObject* card_object = (CardObject*)(*card_object_item);
     card_object_destroy(&card_object);

--- a/source/card.c
+++ b/source/card.c
@@ -187,7 +187,7 @@ Sprite* card_object_get_sprite(CardObject* card_object)
 int card_object_get_buy_price(Item* card_object)
 {
     GBAL_RET_FUNC_RETURN_IF_NULL(card_object, UNDEFINED);
-    ITEM_RETURN_IF_UNEXPECTED_TYPE_RET(card_object, ITEM_TYPE_PLAYING_CARD, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(card_object->type == ITEM_TYPE_PLAYING_CARD, UNDEFINED);
 
     return 1;
 }
@@ -196,7 +196,7 @@ void card_object_dispose(Item** card_object_item)
 {
     GBAL_VOID_FUNC_RETURN_IF_NULL(card_object_item);
     GBAL_VOID_FUNC_RETURN_IF_NULL(*card_object_item);
-    ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(*card_object_item, ITEM_TYPE_PLAYING_CARD);
+    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((*card_object_item)->type == ITEM_TYPE_PLAYING_CARD);
 
     CardObject* card_object = (CardObject*)(*card_object_item);
     card_object_destroy(&card_object);

--- a/source/card.c
+++ b/source/card.c
@@ -186,20 +186,17 @@ Sprite* card_object_get_sprite(CardObject* card_object)
 
 int card_object_get_buy_price(Item* card_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(card_object, UNDEFINED);
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(card_object->type == ITEM_TYPE_PLAYING_CARD, UNDEFINED);
+    GBAL_RETURN_IF_NULL(card_object, UNDEFINED);
+    GBAL_RETURN_IF_ASSERT_FAILS(card_object->type == ITEM_TYPE_PLAYING_CARD, UNDEFINED);
 
     return 1;
 }
 
 void card_object_dispose(Item** card_object_item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(card_object_item, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_NULL(*card_object_item, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(
-        (*card_object_item)->type == ITEM_TYPE_PLAYING_CARD,
-        RET_NONE
-    );
+    GBAL_RETURN_IF_NULL(card_object_item, RET_NONE);
+    GBAL_RETURN_IF_NULL(*card_object_item, RET_NONE);
+    GBAL_RETURN_IF_ASSERT_FAILS((*card_object_item)->type == ITEM_TYPE_PLAYING_CARD, RET_NONE);
 
     CardObject* card_object = (CardObject*)(*card_object_item);
     card_object_destroy(&card_object);

--- a/source/game.c
+++ b/source/game.c
@@ -286,7 +286,7 @@ static inline void held_jokers_update_loop(void)
 
 bool joker_object_can_acquire(Item* joker_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, false);
+    GBAL_RETURN_IF_NULL(joker_object, false);
     return (list_get_len(get_jokers_list()) < MAX_JOKERS_HELD_SIZE);
 }
 

--- a/source/game.c
+++ b/source/game.c
@@ -286,7 +286,7 @@ static inline void held_jokers_update_loop(void)
 
 bool joker_object_can_acquire(Item* joker_object)
 {
-    GBAL_RETURN_IF_NULL_RET(joker_object, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, false);
     return (list_get_len(get_jokers_list()) < MAX_JOKERS_HELD_SIZE);
 }
 

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -1478,7 +1478,7 @@ static inline void round_process_flaming_score(void)
 
 static void joker_scoring_increment_text_cursor(int* cursor_pos_x)
 {
-    GBAL_RETURN_IF_NULL_VOID(cursor_pos_x);
+    GBAL_RETURN_IF_NULL(cursor_pos_x, RET_NONE);
 
     // + 1 For space
     const int joker_score_display_offset_px = (MAX_CARD_SCORE_STR_LEN + 1) * TTE_CHAR_SIZE;
@@ -1495,7 +1495,7 @@ static bool joker_object_score(
     enum JokerEvent joker_event
 )
 {
-    GBAL_RETURN_IF_NULL_RET(joker_object, false);
+    GBAL_RETURN_IF_NULL(joker_object, false);
 
     JokerEffect* joker_effect = NULL;
     u32 effect_flags_ret =

--- a/source/item.c
+++ b/source/item.c
@@ -15,57 +15,57 @@ Item* item_roll_new(enum ItemType item_type, enum RngSequence key)
     }
 
     ItemFuncs* item_funcs = get_item_type_funcs(item_type);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, NULL);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->roll_new, NULL);
+    GBAL_RETURN_IF_NULL(item_funcs, NULL);
+    GBAL_RETURN_IF_NULL(item_funcs->roll_new, NULL);
 
     return item_funcs->roll_new(key);
 }
 
 int item_get_buy_price(Item* item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(item, UNDEFINED);
+    GBAL_RETURN_IF_NULL(item, UNDEFINED);
 
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, UNDEFINED);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->get_buy_price, UNDEFINED);
+    GBAL_RETURN_IF_NULL(item_funcs, UNDEFINED);
+    GBAL_RETURN_IF_NULL(item_funcs->get_buy_price, UNDEFINED);
 
     return item_funcs->get_buy_price(item);
 }
 
 void item_acquire(Item* item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
+    GBAL_RETURN_IF_NULL(item, RET_NONE);
 
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->acquire, RET_NONE);
+    GBAL_RETURN_IF_NULL(item_funcs, RET_NONE);
+    GBAL_RETURN_IF_NULL(item_funcs->acquire, RET_NONE);
 
     item_funcs->acquire(item);
 }
 
 bool item_can_acquire(Item* item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(item, false);
+    GBAL_RETURN_IF_NULL(item, false);
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, false);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->can_acquire, false);
+    GBAL_RETURN_IF_NULL(item_funcs, false);
+    GBAL_RETURN_IF_NULL(item_funcs->can_acquire, false);
 
     return item_funcs->can_acquire(item);
 }
 
 void item_dispose(Item** item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_NULL(*item, RET_NONE);
+    GBAL_RETURN_IF_NULL(item, RET_NONE);
+    GBAL_RETURN_IF_NULL(*item, RET_NONE);
     ItemFuncs* item_funcs = get_item_type_funcs((*item)->type);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->dispose, RET_NONE);
+    GBAL_RETURN_IF_NULL(item_funcs, RET_NONE);
+    GBAL_RETURN_IF_NULL(item_funcs->dispose, RET_NONE);
 
     item_funcs->dispose(item);
 }
 
 void item_print_buy_price_under(Item* item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
+    GBAL_RETURN_IF_NULL(item, RET_NONE);
     sprite_object_print_price_under((SpriteObject*)item, item_get_buy_price(item));
 }

--- a/source/item.c
+++ b/source/item.c
@@ -34,11 +34,11 @@ int item_get_buy_price(Item* item)
 
 void item_acquire(Item* item)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
 
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs->acquire);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->acquire, RET_NONE);
 
     item_funcs->acquire(item);
 }
@@ -55,17 +55,17 @@ bool item_can_acquire(Item* item)
 
 void item_dispose(Item** item)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(*item);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_NULL(*item, RET_NONE);
     ItemFuncs* item_funcs = get_item_type_funcs((*item)->type);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs->dispose);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->dispose, RET_NONE);
 
     item_funcs->dispose(item);
 }
 
 void item_print_buy_price_under(Item* item)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
     sprite_object_print_price_under((SpriteObject*)item, item_get_buy_price(item));
 }

--- a/source/item.c
+++ b/source/item.c
@@ -15,57 +15,57 @@ Item* item_roll_new(enum ItemType item_type, enum RngSequence key)
     }
 
     ItemFuncs* item_funcs = get_item_type_funcs(item_type);
-    GBAL_RETURN_IF_NULL_RET(item_funcs, NULL);
-    GBAL_RETURN_IF_NULL_RET(item_funcs->roll_new, NULL);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, NULL);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->roll_new, NULL);
 
     return item_funcs->roll_new(key);
 }
 
 int item_get_buy_price(Item* item)
 {
-    GBAL_RETURN_IF_NULL_RET(item, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item, UNDEFINED);
 
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_RETURN_IF_NULL_RET(item_funcs, UNDEFINED);
-    GBAL_RETURN_IF_NULL_RET(item_funcs->get_buy_price, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->get_buy_price, UNDEFINED);
 
     return item_funcs->get_buy_price(item);
 }
 
 void item_acquire(Item* item)
 {
-    GBAL_RETURN_IF_NULL_VOID(item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
 
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_RETURN_IF_NULL_VOID(item_funcs);
-    GBAL_RETURN_IF_NULL_VOID(item_funcs->acquire);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs->acquire);
 
     item_funcs->acquire(item);
 }
 
 bool item_can_acquire(Item* item)
 {
-    GBAL_RETURN_IF_NULL_RET(item, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item, false);
     ItemFuncs* item_funcs = get_item_type_funcs(item->type);
-    GBAL_RETURN_IF_NULL_RET(item_funcs, false);
-    GBAL_RETURN_IF_NULL_RET(item_funcs->can_acquire, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item_funcs->can_acquire, false);
 
     return item_funcs->can_acquire(item);
 }
 
 void item_dispose(Item** item)
 {
-    GBAL_RETURN_IF_NULL_VOID(item);
-    GBAL_RETURN_IF_NULL_VOID(*item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(*item);
     ItemFuncs* item_funcs = get_item_type_funcs((*item)->type);
-    GBAL_RETURN_IF_NULL_VOID(item_funcs);
-    GBAL_RETURN_IF_NULL_VOID(item_funcs->dispose);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item_funcs->dispose);
 
     item_funcs->dispose(item);
 }
 
 void item_print_buy_price_under(Item* item)
 {
-    GBAL_RETURN_IF_NULL_VOID(item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
     sprite_object_print_price_under((SpriteObject*)item, item_get_buy_price(item));
 }

--- a/source/item_funcs.c
+++ b/source/item_funcs.c
@@ -55,7 +55,7 @@ static Item* item_roll_new_unimplemented(enum RngSequence key)
 
 static void item_acquire_unimplemented(Item* item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
+    GBAL_RETURN_IF_NULL(item, RET_NONE);
     MGBA_FUNC_ERROR("Unimplemented acquire function called for item type type %d", (item)->type);
 }
 

--- a/source/item_funcs.c
+++ b/source/item_funcs.c
@@ -55,7 +55,7 @@ static Item* item_roll_new_unimplemented(enum RngSequence key)
 
 static void item_acquire_unimplemented(Item* item)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
+    GBAL_RET_FUNC_RETURN_IF_NULL(item, RET_NONE);
     MGBA_FUNC_ERROR("Unimplemented acquire function called for item type type %d", (item)->type);
 }
 

--- a/source/item_funcs.c
+++ b/source/item_funcs.c
@@ -55,7 +55,7 @@ static Item* item_roll_new_unimplemented(enum RngSequence key)
 
 static void item_acquire_unimplemented(Item* item)
 {
-    GBAL_RETURN_IF_NULL_VOID(item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(item);
     MGBA_FUNC_ERROR("Unimplemented acquire function called for item type type %d", (item)->type);
 }
 

--- a/source/joker.c
+++ b/source/joker.c
@@ -4,6 +4,7 @@
 #include "game/round.h"
 #include "game_variables.h"
 #include "graphic_utils.h"
+#include "item.h"
 #include "layout.h"
 #include "mgba_logger.h"
 #include "pool.h"
@@ -13,9 +14,7 @@
 
 // Tiles and palettes
 #include "card_rarity_pal_gfx.h"
-#include "item.h"
 #include "joker_gfx.h"
-#include "util.h"
 
 #include <maxmod.h>
 #include <stdlib.h>

--- a/source/joker.c
+++ b/source/joker.c
@@ -200,6 +200,7 @@ int joker_get_sell_value(const Joker* joker)
 // JokerObject methods
 JokerObject* joker_object_new(Joker* joker)
 {
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker, NULL);
     JokerObject* joker_object = POOL_GET(JokerObject);
 
     sprite_object_init((SpriteObject*)joker_object);

--- a/source/joker.c
+++ b/source/joker.c
@@ -15,6 +15,7 @@
 #include "card_rarity_pal_gfx.h"
 #include "item.h"
 #include "joker_gfx.h"
+#include "util.h"
 
 #include <maxmod.h>
 #include <stdlib.h>
@@ -299,7 +300,7 @@ int joker_object_get_buy_price(Item* joker_object)
 void joker_object_add_to_owned(Item* joker_object)
 {
     GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object);
-    ITEM_VOID_FUNC_RETURN_IF_UNEXPECTED_TYPE(joker_object, ITEM_TYPE_JOKER);
+    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER);
 
     joker_object->ty = int2fx(HELD_JOKERS_POS.y);
     add_joker((JokerObject*)joker_object);

--- a/source/joker.c
+++ b/source/joker.c
@@ -272,7 +272,7 @@ void joker_object_dispose(Item** joker_object_item)
 {
     GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object_item);
     GBAL_VOID_FUNC_RETURN_IF_NULL(*joker_object_item);
-    ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(*joker_object_item, ITEM_TYPE_JOKER);
+    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((*joker_object_item)->type == ITEM_TYPE_JOKER);
 
     JokerObject* joker_object = (JokerObject*)(*joker_object_item);
     GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object->joker);
@@ -291,7 +291,7 @@ void joker_object_shake(JokerObject* joker_object, mm_word sound_id)
 int joker_object_get_buy_price(Item* joker_object)
 {
     GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, UNDEFINED);
-    ITEM_RETURN_IF_UNEXPECTED_TYPE_RET(joker_object, ITEM_TYPE_JOKER, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, UNDEFINED);
 
     return ((JokerObject*)joker_object)->joker->value;
 }
@@ -299,7 +299,7 @@ int joker_object_get_buy_price(Item* joker_object)
 void joker_object_add_to_owned(Item* joker_object)
 {
     GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object);
-    ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(joker_object, ITEM_TYPE_JOKER);
+    ITEM_VOID_FUNC_RETURN_IF_UNEXPECTED_TYPE(joker_object, ITEM_TYPE_JOKER);
 
     joker_object->ty = int2fx(HELD_JOKERS_POS.y);
     add_joker((JokerObject*)joker_object);

--- a/source/joker.c
+++ b/source/joker.c
@@ -185,14 +185,14 @@ u16 joker_get_rarity_color(u8 rarity, bool main_color)
 
 int joker_get_buy_price(const Joker* joker)
 {
-    GBAL_RETURN_IF_NULL_RET(joker, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker, UNDEFINED);
 
     return joker->value;
 }
 
 int joker_get_sell_value(const Joker* joker)
 {
-    GBAL_RETURN_IF_NULL_RET(joker, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker, UNDEFINED);
 
     return joker->value / 2;
 }
@@ -269,12 +269,12 @@ void joker_object_destroy(JokerObject** joker_object)
 
 void joker_object_dispose(Item** joker_object_item)
 {
-    GBAL_RETURN_IF_NULL_VOID(joker_object_item);
-    GBAL_RETURN_IF_NULL_VOID(*joker_object_item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object_item);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(*joker_object_item);
     ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(*joker_object_item, ITEM_TYPE_JOKER);
 
     JokerObject* joker_object = (JokerObject*)(*joker_object_item);
-    GBAL_RETURN_IF_NULL_VOID(joker_object->joker);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object->joker);
 
     joker_set_rollable(joker_object->joker->id, true);
 
@@ -289,7 +289,7 @@ void joker_object_shake(JokerObject* joker_object, mm_word sound_id)
 
 int joker_object_get_buy_price(Item* joker_object)
 {
-    GBAL_RETURN_IF_NULL_RET(joker_object, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, UNDEFINED);
     ITEM_RETURN_IF_UNEXPECTED_TYPE_RET(joker_object, ITEM_TYPE_JOKER, UNDEFINED);
 
     return ((JokerObject*)joker_object)->joker->value;
@@ -297,7 +297,7 @@ int joker_object_get_buy_price(Item* joker_object)
 
 void joker_object_add_to_owned(Item* joker_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(joker_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object);
     ITEM_RETURN_IF_UNEXPECTED_TYPE_VOID(joker_object, ITEM_TYPE_JOKER);
 
     joker_object->ty = int2fx(HELD_JOKERS_POS.y);

--- a/source/joker.c
+++ b/source/joker.c
@@ -270,12 +270,12 @@ void joker_object_destroy(JokerObject** joker_object)
 
 void joker_object_dispose(Item** joker_object_item)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object_item);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(*joker_object_item);
-    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS((*joker_object_item)->type == ITEM_TYPE_JOKER);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object_item, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_NULL(*joker_object_item, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((*joker_object_item)->type == ITEM_TYPE_JOKER, RET_NONE);
 
     JokerObject* joker_object = (JokerObject*)(*joker_object_item);
-    GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object->joker);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object->joker, RET_NONE);
 
     joker_set_rollable(joker_object->joker->id, true);
 
@@ -298,8 +298,8 @@ int joker_object_get_buy_price(Item* joker_object)
 
 void joker_object_add_to_owned(Item* joker_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(joker_object);
-    GBAL_VOID_FUNC_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER);
+    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, RET_NONE);
+    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, RET_NONE);
 
     joker_object->ty = int2fx(HELD_JOKERS_POS.y);
     add_joker((JokerObject*)joker_object);

--- a/source/joker.c
+++ b/source/joker.c
@@ -185,14 +185,14 @@ u16 joker_get_rarity_color(u8 rarity, bool main_color)
 
 int joker_get_buy_price(const Joker* joker)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker, UNDEFINED);
+    GBAL_RETURN_IF_NULL(joker, UNDEFINED);
 
     return joker->value;
 }
 
 int joker_get_sell_value(const Joker* joker)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker, UNDEFINED);
+    GBAL_RETURN_IF_NULL(joker, UNDEFINED);
 
     return joker->value / 2;
 }
@@ -200,7 +200,7 @@ int joker_get_sell_value(const Joker* joker)
 // JokerObject methods
 JokerObject* joker_object_new(Joker* joker)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker, NULL);
+    GBAL_RETURN_IF_NULL(joker, NULL);
     JokerObject* joker_object = POOL_GET(JokerObject);
 
     sprite_object_init((SpriteObject*)joker_object);
@@ -270,12 +270,12 @@ void joker_object_destroy(JokerObject** joker_object)
 
 void joker_object_dispose(Item** joker_object_item)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object_item, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_NULL(*joker_object_item, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS((*joker_object_item)->type == ITEM_TYPE_JOKER, RET_NONE);
+    GBAL_RETURN_IF_NULL(joker_object_item, RET_NONE);
+    GBAL_RETURN_IF_NULL(*joker_object_item, RET_NONE);
+    GBAL_RETURN_IF_ASSERT_FAILS((*joker_object_item)->type == ITEM_TYPE_JOKER, RET_NONE);
 
     JokerObject* joker_object = (JokerObject*)(*joker_object_item);
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object->joker, RET_NONE);
+    GBAL_RETURN_IF_NULL(joker_object->joker, RET_NONE);
 
     joker_set_rollable(joker_object->joker->id, true);
 
@@ -290,16 +290,16 @@ void joker_object_shake(JokerObject* joker_object, mm_word sound_id)
 
 int joker_object_get_buy_price(Item* joker_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, UNDEFINED);
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, UNDEFINED);
+    GBAL_RETURN_IF_NULL(joker_object, UNDEFINED);
+    GBAL_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, UNDEFINED);
 
     return ((JokerObject*)joker_object)->joker->value;
 }
 
 void joker_object_add_to_owned(Item* joker_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(joker_object, RET_NONE);
-    GBAL_RET_FUNC_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, RET_NONE);
+    GBAL_RETURN_IF_NULL(joker_object, RET_NONE);
+    GBAL_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, RET_NONE);
 
     joker_object->ty = int2fx(HELD_JOKERS_POS.y);
     add_joker((JokerObject*)joker_object);

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -185,7 +185,7 @@ void sprite_unhide(Sprite* sprite)
 // SpriteObject methods
 void sprite_object_init(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     sprite_object->sprite = NULL;
     sprite_object_reset_transform(sprite_object);

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -115,15 +115,15 @@ void sprite_destroy(Sprite** sprite)
 
 s16 sprite_get_layer(Sprite* sprite)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, UNDEFINED);
 
     return (s16)(sprite->obj - obj_buffer);
 }
 
 bool sprite_get_width(Sprite* sprite, int* width)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite, false);
-    GBAL_RETURN_IF_NULL_RET(width, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(width, false);
 
     *width = obj_get_width(sprite->obj);
     return true;
@@ -131,8 +131,8 @@ bool sprite_get_width(Sprite* sprite, int* width)
 
 bool sprite_get_height(Sprite* sprite, int* height)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite, false);
-    GBAL_RETURN_IF_NULL_RET(height, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(height, false);
 
     *height = obj_get_height(sprite->obj);
     return true;
@@ -140,9 +140,9 @@ bool sprite_get_height(Sprite* sprite, int* height)
 
 bool sprite_get_dimensions(Sprite* sprite, int* width, int* height)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite, false);
-    GBAL_RETURN_IF_NULL_RET(width, false);
-    GBAL_RETURN_IF_NULL_RET(height, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(width, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(height, false);
 
     const u8* size = obj_get_size(sprite->obj);
     *width = size[0];
@@ -163,21 +163,21 @@ void sprite_draw()
 
 int sprite_get_pb(const Sprite* sprite)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite, UNDEFINED);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, UNDEFINED);
 
     return (sprite->obj->attr2 & ATTR2_PALBANK_MASK) >> ATTR2_PALBANK_SHIFT;
 }
 
 void sprite_hide(Sprite* sprite)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite);
 
     obj_hide(sprite->obj);
 }
 
 void sprite_unhide(Sprite* sprite)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite);
 
     obj_unhide(sprite->obj, sprite->mode);
 }
@@ -196,7 +196,7 @@ void sprite_object_init(SpriteObject* sprite_object)
 
 void sprite_object_destroy(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     list_remove_data(&sprite_objects_list, sprite_object);
     sprite_destroy(&sprite_object->sprite);
@@ -204,7 +204,7 @@ void sprite_object_destroy(SpriteObject* sprite_object)
 
 void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     sprite_destroy(&sprite_object->sprite); // Destroy the old sprite if it exists
     sprite_object->sprite = sprite;
@@ -212,21 +212,21 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 
 void sprite_object_hide(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     sprite_hide(sprite_object->sprite);
 }
 
 void sprite_object_unhide(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     sprite_unhide(sprite_object->sprite);
 }
 
 void sprite_object_reset_transform(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     sprite_object_position(sprite_object, 0, 0); // Target position
     sprite_object->vx = 0;
@@ -349,7 +349,7 @@ void sprite_object_update_all(void)
 
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     sprite_object->vscale = float2fx(0.3f);
     sprite_object->vrotation = float2fx(8.0f); // Rotate the card when it's scored
@@ -362,14 +362,14 @@ void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 
 Sprite* sprite_object_get_sprite(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite_object, NULL);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, NULL);
 
     return sprite_object->sprite;
 }
 
 void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     if (sprite_object->focused == focus)
     {
@@ -387,28 +387,28 @@ void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 
 bool sprite_object_get_width(SpriteObject* sprite_object, int* width)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
 
     return sprite_get_width(sprite_object->sprite, width);
 }
 
 bool sprite_object_get_height(SpriteObject* sprite_object, int* height)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
 
     return sprite_get_height(sprite_object->sprite, height);
 }
 
 bool sprite_object_get_dimensions(SpriteObject* sprite_object, int* width, int* height)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
 
     return sprite_get_dimensions(sprite_object->sprite, width, height);
 }
 
 bool sprite_object_is_focused(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_RET(sprite_object, false);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
     return sprite_object->focused;
 }
 
@@ -418,7 +418,7 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
     int width = 0;
     Rect ret_rect = {0};
 
-    GBAL_RETURN_IF_NULL_RET(sprite_object, ret_rect);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, ret_rect);
 
     if (sprite_object_get_dimensions(sprite_object, &width, &height) == false)
     {
@@ -437,7 +437,7 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
 
 void sprite_object_print_text_under(SpriteObject* sprite_object, const char text[])
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
     update_text_rect_to_center_str(&text_rect, text, SCREEN_LEFT);
@@ -446,7 +446,7 @@ void sprite_object_print_text_under(SpriteObject* sprite_object, const char text
 
 void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     // + 2 for null-terminator and "$"
     char price_str_buff[INT_MAX_DIGITS + 2];
@@ -456,7 +456,7 @@ void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 
 void sprite_object_erase_text_under(SpriteObject* sprite_object)
 {
-    GBAL_RETURN_IF_NULL_VOID(sprite_object);
+    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
 
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
 

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -115,15 +115,15 @@ void sprite_destroy(Sprite** sprite)
 
 s16 sprite_get_layer(Sprite* sprite)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, UNDEFINED);
+    GBAL_RETURN_IF_NULL(sprite, UNDEFINED);
 
     return (s16)(sprite->obj - obj_buffer);
 }
 
 bool sprite_get_width(Sprite* sprite, int* width)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, false);
-    GBAL_RET_FUNC_RETURN_IF_NULL(width, false);
+    GBAL_RETURN_IF_NULL(sprite, false);
+    GBAL_RETURN_IF_NULL(width, false);
 
     *width = obj_get_width(sprite->obj);
     return true;
@@ -131,8 +131,8 @@ bool sprite_get_width(Sprite* sprite, int* width)
 
 bool sprite_get_height(Sprite* sprite, int* height)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, false);
-    GBAL_RET_FUNC_RETURN_IF_NULL(height, false);
+    GBAL_RETURN_IF_NULL(sprite, false);
+    GBAL_RETURN_IF_NULL(height, false);
 
     *height = obj_get_height(sprite->obj);
     return true;
@@ -140,9 +140,9 @@ bool sprite_get_height(Sprite* sprite, int* height)
 
 bool sprite_get_dimensions(Sprite* sprite, int* width, int* height)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, false);
-    GBAL_RET_FUNC_RETURN_IF_NULL(width, false);
-    GBAL_RET_FUNC_RETURN_IF_NULL(height, false);
+    GBAL_RETURN_IF_NULL(sprite, false);
+    GBAL_RETURN_IF_NULL(width, false);
+    GBAL_RETURN_IF_NULL(height, false);
 
     const u8* size = obj_get_size(sprite->obj);
     *width = size[0];
@@ -163,21 +163,21 @@ void sprite_draw()
 
 int sprite_get_pb(const Sprite* sprite)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, UNDEFINED);
+    GBAL_RETURN_IF_NULL(sprite, UNDEFINED);
 
     return (sprite->obj->attr2 & ATTR2_PALBANK_MASK) >> ATTR2_PALBANK_SHIFT;
 }
 
 void sprite_hide(Sprite* sprite)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite, RET_NONE);
 
     obj_hide(sprite->obj);
 }
 
 void sprite_unhide(Sprite* sprite)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite, RET_NONE);
 
     obj_unhide(sprite->obj, sprite->mode);
 }
@@ -185,7 +185,7 @@ void sprite_unhide(Sprite* sprite)
 // SpriteObject methods
 void sprite_object_init(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_object->sprite = NULL;
     sprite_object_reset_transform(sprite_object);
@@ -196,7 +196,7 @@ void sprite_object_init(SpriteObject* sprite_object)
 
 void sprite_object_destroy(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     list_remove_data(&sprite_objects_list, sprite_object);
     sprite_destroy(&sprite_object->sprite);
@@ -204,7 +204,7 @@ void sprite_object_destroy(SpriteObject* sprite_object)
 
 void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_destroy(&sprite_object->sprite); // Destroy the old sprite if it exists
     sprite_object->sprite = sprite;
@@ -212,21 +212,21 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 
 void sprite_object_hide(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_hide(sprite_object->sprite);
 }
 
 void sprite_object_unhide(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_unhide(sprite_object->sprite);
 }
 
 void sprite_object_reset_transform(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_object_position(sprite_object, 0, 0); // Target position
     sprite_object->vx = 0;
@@ -349,7 +349,7 @@ void sprite_object_update_all(void)
 
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_object->vscale = float2fx(0.3f);
     sprite_object->vrotation = float2fx(8.0f); // Rotate the card when it's scored
@@ -362,14 +362,14 @@ void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 
 Sprite* sprite_object_get_sprite(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, NULL);
+    GBAL_RETURN_IF_NULL(sprite_object, NULL);
 
     return sprite_object->sprite;
 }
 
 void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     if (sprite_object->focused == focus)
     {
@@ -387,28 +387,28 @@ void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 
 bool sprite_object_get_width(SpriteObject* sprite_object, int* width)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
+    GBAL_RETURN_IF_NULL(sprite_object, false);
 
     return sprite_get_width(sprite_object->sprite, width);
 }
 
 bool sprite_object_get_height(SpriteObject* sprite_object, int* height)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
+    GBAL_RETURN_IF_NULL(sprite_object, false);
 
     return sprite_get_height(sprite_object->sprite, height);
 }
 
 bool sprite_object_get_dimensions(SpriteObject* sprite_object, int* width, int* height)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
+    GBAL_RETURN_IF_NULL(sprite_object, false);
 
     return sprite_get_dimensions(sprite_object->sprite, width, height);
 }
 
 bool sprite_object_is_focused(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, false);
+    GBAL_RETURN_IF_NULL(sprite_object, false);
     return sprite_object->focused;
 }
 
@@ -418,7 +418,7 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
     int width = 0;
     Rect ret_rect = {0};
 
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, ret_rect);
+    GBAL_RETURN_IF_NULL(sprite_object, ret_rect);
 
     if (sprite_object_get_dimensions(sprite_object, &width, &height) == false)
     {
@@ -437,7 +437,7 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
 
 void sprite_object_print_text_under(SpriteObject* sprite_object, const char text[])
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
     update_text_rect_to_center_str(&text_rect, text, SCREEN_LEFT);
@@ -446,7 +446,7 @@ void sprite_object_print_text_under(SpriteObject* sprite_object, const char text
 
 void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     // + 2 for null-terminator and "$"
     char price_str_buff[INT_MAX_DIGITS + 2];
@@ -456,7 +456,7 @@ void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 
 void sprite_object_erase_text_under(SpriteObject* sprite_object)
 {
-    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
+    GBAL_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
 

--- a/source/sprite.c
+++ b/source/sprite.c
@@ -170,14 +170,14 @@ int sprite_get_pb(const Sprite* sprite)
 
 void sprite_hide(Sprite* sprite)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, RET_NONE);
 
     obj_hide(sprite->obj);
 }
 
 void sprite_unhide(Sprite* sprite)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite, RET_NONE);
 
     obj_unhide(sprite->obj, sprite->mode);
 }
@@ -185,7 +185,7 @@ void sprite_unhide(Sprite* sprite)
 // SpriteObject methods
 void sprite_object_init(SpriteObject* sprite_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_object->sprite = NULL;
     sprite_object_reset_transform(sprite_object);
@@ -196,7 +196,7 @@ void sprite_object_init(SpriteObject* sprite_object)
 
 void sprite_object_destroy(SpriteObject* sprite_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     list_remove_data(&sprite_objects_list, sprite_object);
     sprite_destroy(&sprite_object->sprite);
@@ -204,7 +204,7 @@ void sprite_object_destroy(SpriteObject* sprite_object)
 
 void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_destroy(&sprite_object->sprite); // Destroy the old sprite if it exists
     sprite_object->sprite = sprite;
@@ -212,21 +212,21 @@ void sprite_object_set_sprite(SpriteObject* sprite_object, Sprite* sprite)
 
 void sprite_object_hide(SpriteObject* sprite_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_hide(sprite_object->sprite);
 }
 
 void sprite_object_unhide(SpriteObject* sprite_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_unhide(sprite_object->sprite);
 }
 
 void sprite_object_reset_transform(SpriteObject* sprite_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_object_position(sprite_object, 0, 0); // Target position
     sprite_object->vx = 0;
@@ -349,7 +349,7 @@ void sprite_object_update_all(void)
 
 void sprite_object_shake(SpriteObject* sprite_object, mm_word sound_id)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     sprite_object->vscale = float2fx(0.3f);
     sprite_object->vrotation = float2fx(8.0f); // Rotate the card when it's scored
@@ -369,7 +369,7 @@ Sprite* sprite_object_get_sprite(SpriteObject* sprite_object)
 
 void sprite_object_set_focus(SpriteObject* sprite_object, bool focus)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     if (sprite_object->focused == focus)
     {
@@ -437,7 +437,7 @@ static Rect sprite_object_get_text_rect_under(SpriteObject* sprite_object)
 
 void sprite_object_print_text_under(SpriteObject* sprite_object, const char text[])
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
     update_text_rect_to_center_str(&text_rect, text, SCREEN_LEFT);
@@ -446,7 +446,7 @@ void sprite_object_print_text_under(SpriteObject* sprite_object, const char text
 
 void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     // + 2 for null-terminator and "$"
     char price_str_buff[INT_MAX_DIGITS + 2];
@@ -456,7 +456,7 @@ void sprite_object_print_price_under(SpriteObject* sprite_object, int price)
 
 void sprite_object_erase_text_under(SpriteObject* sprite_object)
 {
-    GBAL_VOID_FUNC_RETURN_IF_NULL(sprite_object);
+    GBAL_RET_FUNC_RETURN_IF_NULL(sprite_object, RET_NONE);
 
     Rect text_rect = sprite_object_get_text_rect_under(sprite_object);
 


### PR DESCRIPTION
I removed the item-specific type-checking macros and replaced them with more generic assert-style macros that are also now used by the NULL-checking macros to avoid duplication.
So now they have the form
```c
GBAL_RETURN_IF_ASSERT_FAILS(joker_object->type == ITEM_TYPE_JOKER, UNDEFINED);
```
I opted to do this instead of `RETURN_IF_EQUALS/UNEQUALS` macros because they felt excessive and that it would be better to just add generic macros.

I also added macros with the functionality to log any custom error message because I thought it might be useful in some situations.
I think it would be shorter to do something like
```c
GBAL_CUST_MSG_RETURN_IF_ASSERT_FAILS(value == expected_val, ret_val, "Unexpected value %d", value);
```
instead of
```c
if (value != expected_val)                                
{                                                 
    MGBA_FUNC_ERROR("Unexpected value %d", value);
    return (ret_val);                             
}
```
But I don't know, I'm not against using the entire if statement but I think the macro could be good to shorten repetitive error checking code so it's less distracting from the actual logic.

I also combined the return value and void function type macros into a single macro, by passing an empty return value argument.
