### PR TITLE
[Feature] Implement Sprite Containers for automatic spacing

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -5,6 +5,7 @@
 #include "game_variables.h"
 #include "graphic_utils.h"
 #include "item.h"
+#include "sprite_container.h"
 
 #include <tonc.h>
 
@@ -74,6 +75,7 @@ bool joker_object_can_acquire(Item* item);
 bool card_is_face(Card* card);
 void add_joker(JokerObject* joker_object);
 void remove_owned_joker(int owned_joker_idx);
+LayoutContainer* get_jokers_container(void);
 List* get_jokers_list(void);
 List* get_expired_jokers_list(void);
 List* get_discarded_jokers_list(void);

--- a/include/game.h
+++ b/include/game.h
@@ -75,8 +75,7 @@ bool joker_object_can_acquire(Item* item);
 bool card_is_face(Card* card);
 void add_joker(JokerObject* joker_object);
 void remove_owned_joker(int owned_joker_idx);
-LayoutContainer* get_jokers_container(void);
-List* get_jokers_list(void);
+SpriteContainer* get_jokers_container(void);
 List* get_expired_jokers_list(void);
 List* get_discarded_jokers_list(void);
 

--- a/include/layout.h
+++ b/include/layout.h
@@ -25,6 +25,8 @@ static const Rect BLIND_REWARD_RECT                    = {40,      32,     64,  
 static const Rect BLIND_REQ_TEXT_RECT                  = {32,      24,     64,     32};
 static const Rect PLAYING_SCREEN_RECT                  = {72,      0,      240,    160};
 static const Rect HAND_SIZE_RECT                       = {128,     128,    152,    160}; // Seems to include both SELECT and PLAYING
+const static Rect OWNED_JOKERS_CONTAINER_RECT          = {72,      12,     176,    44};
+const static Rect SHOP_ITEMS_CONTAINER_RECT            = {114,     165,    190,    201};
 // clang-format on
 
 #endif // LAYOUT_H

--- a/include/sprite_container.h
+++ b/include/sprite_container.h
@@ -1,6 +1,6 @@
 /**
  * @file sprite_container.h
- * @brief Definitions for the LayoutContainer data structure and its handling functions
+ * @brief Definitions for the SpriteContainer data structure and its handling functions
  */
 
 #ifndef SPRITE_CONTAINER_H
@@ -8,6 +8,7 @@
 
 #include "graphic_utils.h"
 #include "list.h"
+#include "sprite.h"
 
 enum LayoutDirection
 {
@@ -25,8 +26,13 @@ enum LayoutJustification
 /**
  * @brief A structure organizing a List of SpriteObjects
  */
-typedef struct LayoutContainer
+typedef struct SpriteContainer
 {
+    /**
+     * @brief List of SpriteObjects to organize
+     */
+    List* contents;
+
     /**
      * @brief A Rect holding the position and size of the Container as follows:
      *         `{left=posX, top=posY, right=width, bottom=height}`
@@ -44,11 +50,6 @@ typedef struct LayoutContainer
     enum LayoutJustification justification;
 
     /**
-     * @brief List of SpriteObjects to organize
-     */
-    List* contents;
-
-    /**
      * @brief The position and size of the object actually represented within their Sprite
      *
      * For the Skip Tags, the sprite is 16x16 ps, but the actual object is only 10x10, which means
@@ -64,25 +65,96 @@ typedef struct LayoutContainer
      *         whole Container.
      */
     int minimum_spacing;
-} LayoutContainer;
+} SpriteContainer;
+
+const static Rect DEFAULT_POS_SIZE_RECT = {0, 0, 1, 1};
+#define SPRITE_CONTAINER_DEFAULT               \
+    {.contents = NULL,                         \
+     .pos = DEFAULT_POS_SIZE_RECT,             \
+     .direction = LAYOUT_DIR_HORIZONTAL,       \
+     .justification = LAYOUT_JUST_CENTER,      \
+     .sprite_pos_size = DEFAULT_POS_SIZE_RECT, \
+     .minimum_spacing = 0}
 
 /**
- * @brief Parse the contents List and give a new target position to every SpriteObject inside
+ * Prepend an entry to the `head` of a @ref SpriteContainer contents
  *
- * Do not run this on every frame, only when the List's contents actually change
+ * @param container pointer to a @ref SpriteContainer
+ * @param sprite_object pointer to a SpriteObject to put into the @ref SpriteContainer
  *
- * @param container the LayoutContainer to update
+ * @sa list_push_front
  */
-void layout_container_update(LayoutContainer* container);
+void container_push_front(SpriteContainer* container, SpriteObject* sprite_object);
 
-#define LAYOUT_CONTAINER_DEFAULT             \
-    {                                        \
-        .pos = {0, 0, 1, 1},                 \
-        .direction = LAYOUT_DIR_HORIZONTAL,  \
-        .justification = LAYOUT_JUST_CENTER, \
-        .contents = NULL                     \
-        .real_pos_size = {0, 0, 1, 1}        \
-        .minimum_spacing = 0                 \
-}
+/**
+ * Append an entry to the `tail` of a @ref SpriteContainer contents
+ *
+ * @param container pointer to a @ref SpriteContainer
+ * @param sprite_object pointer to a SpriteObject to put into the @ref SpriteContainer
+ *
+ * @sa list_push_back
+ */
+void container_push_back(SpriteContainer* container, SpriteObject* sprite_object);
+
+/** Insert a SpriteObject into a @ref SpriteContainer a specific index
+ *
+ * @param container pointer to a @ref SpriteContainer
+ * @param sprite_object pointer to a SpriteObject to put into the @ref SpriteContainer
+ * @param idx desired index to insert
+ *
+ * @sa list_insert
+ */
+void container_insert(SpriteContainer* container, SpriteObject* sprite_object, unsigned int idx);
+
+/**
+ * Swap the data pointers at the specified indices of a @ref SpriteContainer
+ *
+ * If either indices are larger than the length of the underlying list, return false.
+ *
+ * @param container pointer to a @ref SpriteContainer
+ * @param idx_a desired index to swap with idx_b
+ * @param idx_b desired index to swap with idx_a
+ *
+ * @return true if successful, false otherwise
+ *
+ * @sa list_swap
+ */
+bool container_swap(SpriteContainer* container, unsigned int idx_a, unsigned int idx_b);
+
+/**
+ * Remove a SpriteContainer's underlying List node at the specified index
+ *
+ * @param container pointer to a @ref SpriteContainer
+ * @param idx index of the desired @ref ListNode in the container
+ *
+ * @return `true` if successfully removed, `false` if out-of-bounds
+ */
+bool container_remove_at_idx(SpriteContainer* container, unsigned int idx);
+
+/**
+ * Remove a SpriteContainer's underlying List's node with the matching pointer
+ *
+ * @param container pointer to a @ref SpriteContainer
+ * @param sprite_object pointer to a SpriteObject in node in container
+ *
+ * @return `true` if successfully removed, `false` otherwise
+ *
+ * @note When working with @ref ListItr, use @ref list_itr_remove_current_node()
+ */
+bool container_remove_data(SpriteContainer* container, SpriteObject* sprite_object);
+
+/**
+ * @brief Remove the current @ref ListNode from the iterator from the @ref SpriteContainer's underlying
+ *         @ref List.
+ *
+ * @param container pointer to the @ref SpriteContainer to which the iterator's @ref List belongs to
+ * @param itr pointer to the @ref ListItr
+ *
+ * @note When working with @ref ListItr, use this and not @ref container_remove_at_idx() as it will
+ * "break" the iterator.
+ *
+ * @sa list_itr_remove_current_node
+ */
+void container_itr_remove_current_node(SpriteContainer* container, ListItr* itr);
 
 #endif // SPRITE_CONTAINER_H

--- a/include/sprite_container.h
+++ b/include/sprite_container.h
@@ -1,0 +1,21 @@
+
+enum LayoutDirection
+{
+    LAYOUT_DIR_HORIZONTAL,
+    LAYOUT_DIR_VERTICAL,
+    LAYOUT_DIR_MAX
+};
+
+enum LayoutJustification
+{
+    LAYOUT_JUST_LEFT,
+    LAYOUT_JUST_CENTER
+}
+
+typedef struct LayoutContainer
+{
+    Rect pos;
+    enum LayoutDirection direction;
+    
+    List* contents;
+} LayoutContainer;

--- a/include/sprite_container.h
+++ b/include/sprite_container.h
@@ -10,6 +10,8 @@
 #include "list.h"
 #include "sprite.h"
 
+const static Rect CARD_SPRITE_LOCAL_AABB = {4, 0, 28, 32};
+
 enum LayoutDirection
 {
     LAYOUT_DIR_HORIZONTAL,
@@ -34,8 +36,7 @@ typedef struct SpriteContainer
     List* contents;
 
     /**
-     * @brief A Rect holding the position and size of the Container as follows:
-     *         `{left=posX, top=posY, right=width, bottom=height}`
+     * @brief A Rect holding the position and size of the Container
      */
     Rect pos;
 
@@ -50,15 +51,15 @@ typedef struct SpriteContainer
     enum LayoutJustification justification;
 
     /**
-     * @brief The position and size of the object actually represented within their Sprite
+     * @brief A Rect representing the actual, local position/size of the art within their Sprite.
      *
      * For the Skip Tags, the sprite is 16x16 ps, but the actual object is only 10x10, which means
-     * that `real_pos_size` will be `{2, 2, 10, 10}`
+     * that `real_pos_size` will be `{3, 3, 13, 13}`, or `{4, 0, 28, 32}` for Jokers, Cards, etc
      *
-     * The Sprites should all be uniform within a single Container, hence why we'll save memory space
-     * by storing the information here instead of in each Sprite
+     * The Sprites should all be uniform within a single Container, hence why we'll save memory
+     * space by storing the information here instead of in each Sprite
      */
-    Rect sprite_pos_size;
+    Rect sprite_local_aabb;
 
     /**
      * @brief By how much do we need to space the Sprites, in case there are not enough to fill the
@@ -67,14 +68,17 @@ typedef struct SpriteContainer
     int minimum_spacing;
 } SpriteContainer;
 
+// clang-format off
 const static Rect DEFAULT_POS_SIZE_RECT = {0, 0, 1, 1};
-#define SPRITE_CONTAINER_DEFAULT               \
-    {.contents = NULL,                         \
-     .pos = DEFAULT_POS_SIZE_RECT,             \
-     .direction = LAYOUT_DIR_HORIZONTAL,       \
-     .justification = LAYOUT_JUST_CENTER,      \
-     .sprite_pos_size = DEFAULT_POS_SIZE_RECT, \
-     .minimum_spacing = 0}
+#define SPRITE_CONTAINER_DEFAULT {              \
+    .contents          = NULL,                  \
+    .pos               = DEFAULT_POS_SIZE_RECT, \
+    .direction         = LAYOUT_DIR_HORIZONTAL, \
+    .justification     = LAYOUT_JUST_CENTER,    \
+    .sprite_local_aabb = DEFAULT_POS_SIZE_RECT, \
+    .minimum_spacing   = 0                      \
+}
+// clang-format on
 
 /**
  * Prepend an entry to the `head` of a @ref SpriteContainer contents
@@ -144,8 +148,8 @@ bool container_remove_at_idx(SpriteContainer* container, unsigned int idx);
 bool container_remove_data(SpriteContainer* container, SpriteObject* sprite_object);
 
 /**
- * @brief Remove the current @ref ListNode from the iterator from the @ref SpriteContainer's underlying
- *         @ref List.
+ * @brief Remove the current @ref ListNode from the iterator from the @ref SpriteContainer's
+ *         underlying @ref List.
  *
  * @param container pointer to the @ref SpriteContainer to which the iterator's @ref List belongs to
  * @param itr pointer to the @ref ListItr

--- a/include/sprite_container.h
+++ b/include/sprite_container.h
@@ -1,3 +1,13 @@
+/**
+ * @file sprite_container.h
+ * @brief Definitions for the LayoutContainer data structure and its handling functions
+ */
+
+#ifndef SPRITE_CONTAINER_H
+#define SPRITE_CONTAINER_H
+
+#include "graphic_utils.h"
+#include "list.h"
 
 enum LayoutDirection
 {
@@ -8,14 +18,71 @@ enum LayoutDirection
 
 enum LayoutJustification
 {
-    LAYOUT_JUST_LEFT,
+    LAYOUT_JUST_BEGIN,
     LAYOUT_JUST_CENTER
-}
+};
 
+/**
+ * @brief A structure organizing a List of SpriteObjects
+ */
 typedef struct LayoutContainer
 {
+    /**
+     * @brief A Rect holding the position and size of the Container as follows:
+     *         `{left=posX, top=posY, right=width, bottom=height}`
+     */
     Rect pos;
+
+    /**
+     * @brief Whether the sprites are to be organized horizontally or vertically
+     */
     enum LayoutDirection direction;
-    
+
+    /**
+     * @brief Determines the alignment of the sprites
+     */
+    enum LayoutJustification justification;
+
+    /**
+     * @brief List of SpriteObjects to organize
+     */
     List* contents;
+
+    /**
+     * @brief The position and size of the object actually represented within their Sprite
+     *
+     * For the Skip Tags, the sprite is 16x16 ps, but the actual object is only 10x10, which means
+     * that `real_pos_size` will be `{2, 2, 10, 10}`
+     *
+     * The Sprites should all be uniform within a single Container, hence why we'll save memory space
+     * by storing the information here instead of in each Sprite
+     */
+    Rect sprite_pos_size;
+
+    /**
+     * @brief By how much do we need to space the Sprites, in case there are not enough to fill the
+     *         whole Container.
+     */
+    int minimum_spacing;
 } LayoutContainer;
+
+/**
+ * @brief Parse the contents List and give a new target position to every SpriteObject inside
+ *
+ * Do not run this on every frame, only when the List's contents actually change
+ *
+ * @param container the LayoutContainer to update
+ */
+void layout_container_update(LayoutContainer* container);
+
+#define LAYOUT_CONTAINER_DEFAULT             \
+    {                                        \
+        .pos = {0, 0, 1, 1},                 \
+        .direction = LAYOUT_DIR_HORIZONTAL,  \
+        .justification = LAYOUT_JUST_CENTER, \
+        .contents = NULL                     \
+        .real_pos_size = {0, 0, 1, 1}        \
+        .minimum_spacing = 0                 \
+}
+
+#endif // SPRITE_CONTAINER_H

--- a/include/sprite_container.h
+++ b/include/sprite_container.h
@@ -51,13 +51,16 @@ typedef struct SpriteContainer
     enum LayoutJustification justification;
 
     /**
-     * @brief A Rect representing the actual, local position/size of the art within their Sprite.
+     * @brief A Rect representing the actual, local position/size of the art within the Sprites.
      *
-     * For the Skip Tags, the sprite is 16x16 ps, but the actual object is only 10x10, which means
-     * that `real_pos_size` will be `{3, 3, 13, 13}`, or `{4, 0, 28, 32}` for Jokers, Cards, etc
+     * Examples:
+     *   - For the Skip Tags, the sprite is 16x16 px, but the actual art always fits within
+     *     a centered 10x10 px square, which gives `{3, 3, 13, 13}`
+     *   - For the Jokers, Cards, Planets etc, they are generally rectangles of 24x32 px centered
+     *     in a 32x32 px sprite, which gives `{4, 0, 28, 32}`
      *
-     * The Sprites should all be uniform within a single Container, hence why we'll save memory
-     * space by storing the information here instead of in each Sprite
+     * The Sprites should all be uniform within a single Container, so this is stored here instead
+     * of per-sprite.
      */
     Rect sprite_local_aabb;
 

--- a/source/game.c
+++ b/source/game.c
@@ -129,20 +129,20 @@ GameVariables g_game_vars = {
 };
 // clang-format on
 
+const static Rect s_owned_jokers_container_pos_size = {72, 12, 104, 32};
+const static Rect s_cards_sprite_pos_size = {4,  0,  24,  32};
 static List s_owned_jokers_list;
+static SpriteContainer s_owned_jokers_container = {
+    .contents = &s_owned_jokers_list,
+    .pos = s_owned_jokers_container_pos_size,
+    .direction = LAYOUT_DIR_HORIZONTAL,
+    .justification = LAYOUT_JUST_CENTER,
+    .sprite_pos_size = s_cards_sprite_pos_size,
+    .minimum_spacing = 6
+};
+
 static List s_discarded_jokers_list;
 static List s_expired_jokers_list;
-
-static const Rect s_held_jokers_rect = {72, 12, 104, 32};
-static const Rect s_held_jokers_pos_size = {4, 0, 24, 32};
-static LayoutContainer s_held_jokers_container = {
-    s_held_jokers_rect,
-    LAYOUT_DIR_HORIZONTAL,
-    LAYOUT_JUST_CENTER,
-    &s_owned_jokers_list,
-    s_held_jokers_pos_size,
-    6
-};
 
 // Stacks
 static Card* s_deck[MAX_DECK_SIZE] = {NULL};
@@ -185,7 +185,6 @@ void game_init()
     state_machine_remove(&game_sm);
     state_machine_register(&game_sm);
     // Initialize all jokers list once
-    s_owned_jokers_list = list_init();
     s_discarded_jokers_list = list_init();
     s_expired_jokers_list = list_init();
     // TODO: Move this to an initialization of the play scoring states
@@ -214,9 +213,9 @@ void game_init()
 
 void game_reset()
 {
-    while (list_get_len(&s_owned_jokers_list) > 0)
+    while (list_get_len(s_owned_jokers_container.contents) > 0)
     {
-        JokerObject* joker_object = list_get_at_idx(&s_owned_jokers_list, 0);
+        JokerObject* joker_object = list_get_at_idx(s_owned_jokers_container.contents, 0);
         remove_owned_joker(0);
         joker_object_destroy(&joker_object);
     }
@@ -229,7 +228,7 @@ void game_reset()
     sprite_destroy(&g_game_vars.playing_blind_token);
     sprite_destroy(&g_game_vars.round_end_blind_token);
 
-    list_clear(&s_owned_jokers_list);
+    list_clear(s_owned_jokers_container.contents);
     list_clear(&s_discarded_jokers_list);
     list_clear(&s_expired_jokers_list);
 
@@ -273,7 +272,7 @@ static inline void discarded_jokers_update_loop(void)
 bool joker_object_can_acquire(Item* joker_object)
 {
     GBAL_RETURN_IF_NULL_RET(joker_object, false);
-    return (list_get_len(get_jokers_list()) < MAX_JOKERS_HELD_SIZE);
+    return (list_get_len(s_owned_jokers_container.contents) < MAX_JOKERS_HELD_SIZE);
 }
 
 static inline void expired_jokers_update_loop(void)
@@ -293,7 +292,7 @@ static inline void expired_jokers_update_loop(void)
         {
             // get joker idx
             int expired_joker_idx = 0;
-            ListItr joker_itr = list_itr_create(&s_owned_jokers_list);
+            ListItr joker_itr = list_itr_create(s_owned_jokers_container.contents);
             JokerObject* expired_joker;
             while ((expired_joker = list_itr_next(&joker_itr)) && expired_joker != joker_object)
             {
@@ -305,7 +304,7 @@ static inline void expired_jokers_update_loop(void)
             // the other owned Jokers rearranging themselves to fill the newly
             // freed space, therefore obscuring the animation
             remove_owned_joker(expired_joker_idx);
-            list_itr_remove_current_node(&itr);
+            container_itr_remove_current_node(&s_owned_jokers_container, &itr);
             joker_object_destroy(&joker_object);
         }
     }
@@ -344,7 +343,7 @@ enum GameState game_get_state(void)
 
 bool is_joker_owned(int joker_id)
 {
-    ListItr itr = list_itr_create(&s_owned_jokers_list);
+    ListItr itr = list_itr_create(s_owned_jokers_container.contents);
     JokerObject* joker;
 
     while ((joker = list_itr_next(&itr)))
@@ -357,14 +356,9 @@ bool is_joker_owned(int joker_id)
     return false;
 }
 
-LayoutContainer* get_jokers_container(void)
+SpriteContainer* get_jokers_container(void)
 {
-    return &s_held_jokers_container;
-}
-
-List* get_jokers_list(void)
-{
-    return &s_owned_jokers_list;
+    return &s_owned_jokers_container;
 }
 
 List* get_expired_jokers_list(void)
@@ -390,8 +384,7 @@ int get_straight_and_flush_size(void)
 
 void add_joker(JokerObject* joker_object)
 {
-    list_push_back(&s_owned_jokers_list, joker_object);
-    layout_container_update(&s_held_jokers_container);
+    container_push_back(&s_owned_jokers_container, (SpriteObject*)joker_object);
 
     // TODO: Extract to on_joker_added() callback
     // In case the player gets multiple Four Fingers Jokers,
@@ -410,7 +403,7 @@ void add_joker(JokerObject* joker_object)
 void remove_owned_joker(int owned_joker_idx)
 {
     // TODO: Extract to on_joker_removed() callback
-    JokerObject* joker_object = list_get_at_idx(&s_owned_jokers_list, owned_joker_idx);
+    JokerObject* joker_object = list_get_at_idx(s_owned_jokers_container.contents, owned_joker_idx);
     // In case the player gets multiple Four Fingers Jokers,
     // and only reset the size when all of them have been removed
     if (joker_object->joker->id == FOUR_FINGERS_JOKER_ID)
@@ -425,8 +418,7 @@ void remove_owned_joker(int owned_joker_idx)
 
     // TODO: Move to site of joker_destroy()?
     joker_set_rollable(joker_object->joker->id, true);
-    list_remove_at_idx(&s_owned_jokers_list, owned_joker_idx);
-    layout_container_update(&s_held_jokers_container);
+    container_remove_at_idx(&s_owned_jokers_container, owned_joker_idx);
 }
 
 int get_deck_top(void)

--- a/source/game.c
+++ b/source/game.c
@@ -133,6 +133,17 @@ static List s_owned_jokers_list;
 static List s_discarded_jokers_list;
 static List s_expired_jokers_list;
 
+static const Rect s_held_jokers_rect = {72, 12, 104, 32};
+static const Rect s_held_jokers_pos_size = {4, 0, 24, 32};
+static LayoutContainer s_held_jokers_container = {
+    s_held_jokers_rect,
+    LAYOUT_DIR_HORIZONTAL,
+    LAYOUT_JUST_CENTER,
+    &s_owned_jokers_list,
+    s_held_jokers_pos_size,
+    6
+};
+
 // Stacks
 static Card* s_deck[MAX_DECK_SIZE] = {NULL};
 static int s_deck_top = -1;
@@ -259,31 +270,6 @@ static inline void discarded_jokers_update_loop(void)
     }
 }
 
-static inline void held_jokers_update_loop(void)
-{
-    static const int SPACING_LUT[MAX_JOKERS_HELD_SIZE][MAX_JOKERS_HELD_SIZE] = {
-        {0,  0,   0,   0,   0  },
-        {13, -13, 0,   0,   0  },
-        {26, 0,   -26, 0,   0  },
-        {39, 13,  -13, -39, 0  },
-        {40, 20,  0,   -20, -40}
-    };
-
-    FIXED hand_x = int2fx(HELD_JOKERS_POS.x);
-
-    ListItr itr = list_itr_create(&s_owned_jokers_list);
-    JokerObject* joker;
-    int jokers_top = list_get_len(&s_owned_jokers_list) - 1;
-    int i = 0;
-    while ((joker = list_itr_next(&itr)))
-    {
-        // Let the Shop handle the position of this Joker
-        if (joker != game_shop_get_description_card())
-            joker->tx = hand_x - int2fx(SPACING_LUT[jokers_top][i]);
-        i++;
-    }
-}
-
 bool joker_object_can_acquire(Item* joker_object)
 {
     GBAL_RETURN_IF_NULL_RET(joker_object, false);
@@ -327,7 +313,6 @@ static inline void expired_jokers_update_loop(void)
 
 static inline void jokers_update_loop(void)
 {
-    held_jokers_update_loop();
     discarded_jokers_update_loop();
     expired_jokers_update_loop();
 }
@@ -372,6 +357,11 @@ bool is_joker_owned(int joker_id)
     return false;
 }
 
+LayoutContainer* get_jokers_container(void)
+{
+    return &s_held_jokers_container;
+}
+
 List* get_jokers_list(void)
 {
     return &s_owned_jokers_list;
@@ -401,6 +391,7 @@ int get_straight_and_flush_size(void)
 void add_joker(JokerObject* joker_object)
 {
     list_push_back(&s_owned_jokers_list, joker_object);
+    layout_container_update(&s_held_jokers_container);
 
     // TODO: Extract to on_joker_added() callback
     // In case the player gets multiple Four Fingers Jokers,
@@ -435,6 +426,7 @@ void remove_owned_joker(int owned_joker_idx)
     // TODO: Move to site of joker_destroy()?
     joker_set_rollable(joker_object->joker->id, true);
     list_remove_at_idx(&s_owned_jokers_list, owned_joker_idx);
+    layout_container_update(&s_held_jokers_container);
 }
 
 int get_deck_top(void)

--- a/source/game.c
+++ b/source/game.c
@@ -129,16 +129,14 @@ GameVariables g_game_vars = {
 };
 // clang-format on
 
-const static Rect s_owned_jokers_container_pos_size = {72, 12, 104, 32};
-const static Rect s_cards_sprite_pos_size = {4,  0,  24,  32};
 static List s_owned_jokers_list;
 static SpriteContainer s_owned_jokers_container = {
     .contents = &s_owned_jokers_list,
-    .pos = s_owned_jokers_container_pos_size,
+    .pos = OWNED_JOKERS_CONTAINER_RECT,
     .direction = LAYOUT_DIR_HORIZONTAL,
     .justification = LAYOUT_JUST_CENTER,
-    .sprite_pos_size = s_cards_sprite_pos_size,
-    .minimum_spacing = 6
+    .sprite_local_aabb = CARD_SPRITE_LOCAL_AABB,
+    .minimum_spacing = 8
 };
 
 static List s_discarded_jokers_list;

--- a/source/game.c
+++ b/source/game.c
@@ -302,7 +302,7 @@ static inline void expired_jokers_update_loop(void)
             // the other owned Jokers rearranging themselves to fill the newly
             // freed space, therefore obscuring the animation
             remove_owned_joker(expired_joker_idx);
-            container_itr_remove_current_node(&s_owned_jokers_container, &itr);
+            list_itr_remove_current_node(&itr);
             joker_object_destroy(&joker_object);
         }
     }

--- a/source/game/game_over.c
+++ b/source/game/game_over.c
@@ -140,7 +140,7 @@ static void game_over_common_init(enum EndCondition init_condition)
 
     // Hide all Joker sprites
     JokerObject* joker_object = NULL;
-    ListItr itr = list_itr_create(get_jokers_list());
+    ListItr itr = list_itr_create(get_jokers_container()->contents);
     while ((joker_object = list_itr_next(&itr)))
     {
         obj_hide(joker_object->sprite->obj);

--- a/source/game/joker_row.c
+++ b/source/game/joker_row.c
@@ -68,6 +68,7 @@ bool jokers_sel_row_on_selection_changed(
             (unsigned int)prev_selection->x,
             (unsigned int)new_selection->x
         );
+        layout_container_update(get_jokers_container());
     }
 
     return true;

--- a/source/game/joker_row.c
+++ b/source/game/joker_row.c
@@ -10,7 +10,7 @@
 
 int jokers_sel_row_get_size(void)
 {
-    return list_get_len(get_jokers_list());
+    return list_get_len(get_jokers_container()->contents);
 }
 
 bool jokers_sel_row_on_selection_changed(
@@ -20,7 +20,7 @@ bool jokers_sel_row_on_selection_changed(
     const Selection* new_selection
 )
 {
-    List* owned_jokers_list = get_jokers_list();
+    SpriteContainer* owned_jokers_container = get_jokers_container();
 
     // swap Jokers if the A button is held down and all Jokers are on the same row
     bool swapping =
@@ -29,7 +29,7 @@ bool jokers_sel_row_on_selection_changed(
     if (prev_selection->y == row_idx)
     {
         JokerObject* joker_object =
-            (JokerObject*)list_get_at_idx(owned_jokers_list, prev_selection->x);
+            (JokerObject*)list_get_at_idx(owned_jokers_container->contents, prev_selection->x);
         // Don't change focus from current Joker if swapping
         if (joker_object != NULL && !swapping)
         {
@@ -41,7 +41,7 @@ bool jokers_sel_row_on_selection_changed(
     if (new_selection->y == row_idx)
     {
         JokerObject* joker_object =
-            (JokerObject*)list_get_at_idx(owned_jokers_list, new_selection->x);
+            (JokerObject*)list_get_at_idx(owned_jokers_container->contents, new_selection->x);
         if (joker_object != NULL)
         {
             if (!swapping)
@@ -63,12 +63,11 @@ bool jokers_sel_row_on_selection_changed(
 
     if (swapping)
     {
-        list_swap(
-            owned_jokers_list,
+        container_swap(
+            owned_jokers_container,
             (unsigned int)prev_selection->x,
             (unsigned int)new_selection->x
         );
-        layout_container_update(get_jokers_container());
     }
 
     return true;
@@ -83,7 +82,7 @@ static inline void joker_start_discard_animation(JokerObject* joker_object)
 
 static inline void game_sell_joker(int joker_idx)
 {
-    List* owned_jokers_list = get_jokers_list();
+    List* owned_jokers_list = get_jokers_container()->contents;
 
     if (joker_idx < 0 || joker_idx >= list_get_len(owned_jokers_list))
         return;
@@ -100,7 +99,8 @@ static inline void game_sell_joker(int joker_idx)
 
 void jokers_sel_row_on_key_transit(SelectionGrid* selection_grid, Selection* selection)
 {
-    JokerObject* joker_object = (JokerObject*)list_get_at_idx(get_jokers_list(), selection->x);
+    JokerObject* joker_object =
+        (JokerObject*)list_get_at_idx(get_jokers_container()->contents, selection->x);
     if (joker_object != NULL)
     {
         if (key_hit(SELECT_CARD))

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -1516,7 +1516,7 @@ static inline void play_starting_played_cards_update(int played_idx)
 
         if (s_scored_card_index == 0)
         {
-            s_joker_scored_itr = list_itr_create(get_jokers_list());
+            s_joker_scored_itr = list_itr_create(get_jokers_container()->contents);
             g_game_vars.timer = TM_ZERO;
             play_state = PLAY_BEFORE_SCORING;
         }
@@ -1575,7 +1575,7 @@ static inline bool play_scoring_cards_update(void)
         if (s_scored_card_index > s_played_top)
         {
             // reuse these variables for held cards
-            s_joker_scored_itr = list_itr_create(get_jokers_list());
+            s_joker_scored_itr = list_itr_create(get_jokers_container()->contents);
             s_scored_card_index = get_hand_top();
 
             play_state = PLAY_SCORING_HELD_CARDS;
@@ -1609,8 +1609,8 @@ static inline bool play_scoring_cards_update(void)
             display_chips();
 
             // Allow Joker scoring
-            s_joker_scored_itr = list_itr_create(get_jokers_list());
-            s_joker_card_scored_end_itr = list_itr_create(get_jokers_list());
+            s_joker_scored_itr = list_itr_create(get_jokers_container()->contents);
+            s_joker_card_scored_end_itr = list_itr_create(get_jokers_container()->contents);
         }
 
         play_state = PLAY_SCORING_CARD_JOKERS;
@@ -1697,11 +1697,11 @@ static inline bool play_scoring_held_cards_update(int played_idx)
                 card_object_shake(hand[s_scored_card_index], SFX_CARD_SELECT);
                 return true;
             }
-            s_joker_scored_itr = list_itr_create(get_jokers_list());
+            s_joker_scored_itr = list_itr_create(get_jokers_container()->contents);
         }
 
         s_scored_card_index = 0;
-        s_joker_round_end_itr = list_itr_create(get_jokers_list());
+        s_joker_round_end_itr = list_itr_create(get_jokers_container()->contents);
         play_state = PLAY_SCORING_INDEPENDENT_JOKERS;
     }
 
@@ -1858,7 +1858,7 @@ static bool play_ended_played_cards_update(int played_idx)
                 hand_set_nb_selected_cards(0);
                 s_played_top = -1; // Reset the played stack
                 s_scored_card_index = 0;
-                s_joker_scored_itr = list_itr_create(get_jokers_list());
+                s_joker_scored_itr = list_itr_create(get_jokers_container()->contents);
                 g_game_vars.timer = TM_ZERO;
             }
 
@@ -1974,7 +1974,7 @@ static inline void played_cards_update_loop(void)
 
 void game_round_on_init(void)
 {
-    s_joker_scored_itr = list_itr_create(get_jokers_list());
+    s_joker_scored_itr = list_itr_create(get_jokers_container()->contents);
 
     set_hand_state(HAND_DRAW);
     hand_set_nb_selected_cards(0);

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -564,8 +564,8 @@ static void game_shop_process_user_input(void)
         // Owned Joker
         case 0:
         {
-            s_description_card_original_list = get_jokers_list();
-            tmp_card = list_get_at_idx(get_jokers_list(), shop_selection_grid.selection.x);
+            s_description_card_original_list = get_jokers_container()->contents;
+            tmp_card = list_get_at_idx(get_jokers_container()->contents, shop_selection_grid.selection.x);
             break;
         }
 
@@ -622,7 +622,7 @@ static void game_shop_show_card_desc(void)
         JokerObject* joker_object = NULL;
 
         // Owned Jokers
-        ListItr itr = list_itr_create(get_jokers_list());
+        ListItr itr = list_itr_create(get_jokers_container()->contents);
         while ((joker_object = list_itr_next(&itr)))
         {
             if (joker_object != s_description_card)
@@ -740,7 +740,7 @@ static void game_shop_hide_card_desc(void)
         JokerObject* joker_object = NULL;
 
         // Owned Jokers
-        ListItr itr = list_itr_create(get_jokers_list());
+        ListItr itr = list_itr_create(get_jokers_container()->contents);
         while ((joker_object = list_itr_next(&itr)))
         {
             if (joker_object != s_description_card)
@@ -814,7 +814,7 @@ static void game_shop_hide_card_desc(void)
     // At any point after the other prices have been printed, and while the card is still moving,
     // if we are NOT pressing A, print the price under it.
     else if (!owned_joker_price_printed && !key_held(SELECT_CARD) &&
-             s_description_card_original_list == get_jokers_list())
+             s_description_card_original_list == get_jokers_container()->contents)
     {
         owned_joker_price_printed = true;
         sprite_object_print_price_under(

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -90,6 +90,14 @@ static const Rect     SHOP_REROLL_RECT            = { 88,  96, UNDEFINED, UNDEFI
 // clang-format on
 
 static List s_shop_items_list = LIST_DEFAULT;
+static SpriteContainer s_shop_items_container = {
+    .contents = &s_shop_items_list,
+    .pos = SHOP_ITEMS_CONTAINER_RECT,
+    .direction = LAYOUT_DIR_HORIZONTAL,
+    .justification = LAYOUT_JUST_CENTER,
+    .sprite_local_aabb = CARD_SPRITE_LOCAL_AABB,
+    .minimum_spacing = 8
+};
 
 enum GameShopStates
 {
@@ -186,8 +194,8 @@ JokerObject* game_shop_get_description_card(void)
 
 void game_shop_reset(void)
 {
-    list_clear(&s_shop_items_list);
-    s_shop_items_list = list_init();
+    list_clear(s_shop_items_container.contents);
+    *(s_shop_items_container.contents) = list_init();
     joker_reset_rollable_jokers();
 }
 
@@ -248,10 +256,8 @@ static void game_shop_create_top_row_items(void)
 {
     tte_erase_rect_wrapper(SHOP_PRICES_TEXT_RECT);
 
-    List* shop_items_list = &s_shop_items_list;
-
-    list_clear(shop_items_list);
-    *shop_items_list = list_init();
+    list_clear(s_shop_items_container.contents);
+    *(s_shop_items_container.contents) = list_init();
 
     for (int i = 0; i < MAX_SHOP_ITEMS; i++)
     {
@@ -275,8 +281,19 @@ static void game_shop_create_top_row_items(void)
 
         item_print_buy_price_under(item);
 
-        list_push_back(shop_items_list, item);
+        container_push_back(&s_shop_items_container, (SpriteObject*)item);
     }
+}
+
+static void game_shop_display_reroll_cost(void)
+{
+    tte_printf(
+        "#{P:%d,%d; cx:0x%X000}$%d",
+        SHOP_REROLL_RECT.left,
+        SHOP_REROLL_RECT.top,
+        TTE_WHITE_PB,
+        s_reroll_cost
+    );
 }
 
 /**
@@ -315,13 +332,7 @@ static void game_shop_intro()
         s_timer = TM_ZERO; // Reset the timer
 
         // print initial reroll cost only when the panel is in place
-        tte_printf(
-            "#{P:%d,%d; cx:0x%X000}$%d",
-            SHOP_REROLL_RECT.left,
-            SHOP_REROLL_RECT.top,
-            TTE_WHITE_PB,
-            s_reroll_cost
-        );
+        game_shop_display_reroll_cost();
     }
 }
 
@@ -332,7 +343,7 @@ static void game_shop_intro()
 static int shop_top_row_get_size(void)
 {
     // + 1 to account for next round button
-    return list_get_len(&s_shop_items_list) + 1;
+    return list_get_len(s_shop_items_container.contents) + 1;
 }
 
 /**
@@ -340,15 +351,26 @@ static int shop_top_row_get_size(void)
  */
 static inline void game_shop_buy_item(int shop_item_idx)
 {
-    List* shop_items_list = &s_shop_items_list;
-    Item* item = (Item*)list_get_at_idx(shop_items_list, shop_item_idx);
+    Item* item = (Item*)list_get_at_idx(s_shop_items_container.contents, shop_item_idx);
 
     g_game_vars.money -= item_get_buy_price(item);
     display_money();
     sprite_object_erase_text_under((SpriteObject*)item);
     sprite_object_set_focus((SpriteObject*)item, false);
     item_acquire(item);
-    list_remove_at_idx(shop_items_list, shop_item_idx); // Remove the joker from the shop
+
+    // Remove the joker from the shop
+    container_remove_at_idx(&s_shop_items_container, shop_item_idx);
+
+    // Update prices position under remaining Items
+    tte_erase_rect_wrapper(SHOP_PRICES_TEXT_RECT);
+    game_shop_display_reroll_cost();
+    item = NULL;
+    ListItr itr = list_itr_create(s_shop_items_container.contents);
+    while ((item = list_itr_next(&itr)))
+    {
+        item_print_buy_price_under(item);
+    }
 }
 
 /**
@@ -366,7 +388,7 @@ static void shop_top_row_on_key_transit(SelectionGrid* selection_grid, Selection
     else
     {
         int shop_item_idx = selection->x - 1; // - 1 to account for next round button
-        Item* item = (Item*)list_get_at_idx(&s_shop_items_list, shop_item_idx);
+        Item* item = (Item*)list_get_at_idx(s_shop_items_container.contents, shop_item_idx);
         if (!item_can_acquire(item) || g_game_vars.money < item_get_buy_price(item))
         {
             return;
@@ -387,7 +409,7 @@ static bool shop_top_row_on_selection_changed(
     const Selection* new_selection
 )
 {
-    List* shop_items_list = &s_shop_items_list;
+    List* shop_items_list = s_shop_items_container.contents;
     // Guard if we move down while on jokers
     if (new_selection->y > row_idx && prev_selection->x > 0)
         return false;
@@ -454,7 +476,8 @@ static bool shop_reroll_row_on_selection_changed(
         if (new_selection->x != NEXT_ROUND_BTN_SEL_X)
         {
             int idx = new_selection->x - 1;
-            SpriteObject* sprite_object = (SpriteObject*)list_get_at_idx(&s_shop_items_list, idx);
+            SpriteObject* sprite_object =
+                (SpriteObject*)list_get_at_idx(s_shop_items_container.contents, idx);
             sprite_object_set_focus(sprite_object, true);
         }
     }
@@ -475,7 +498,7 @@ static inline void game_shop_reroll(void)
     g_game_vars.money -= s_reroll_cost;
     display_money(); // Update the money display
 
-    List* shop_items_list = &s_shop_items_list;
+    List* shop_items_list = s_shop_items_container.contents;
     ListItr itr = list_itr_create(shop_items_list);
     Item* item;
 
@@ -506,13 +529,7 @@ static inline void game_shop_reroll(void)
     }
 
     s_reroll_cost++;
-    tte_printf(
-        "#{P:%d,%d; cx:0x%X000}$%d",
-        SHOP_REROLL_RECT.left,
-        SHOP_REROLL_RECT.top,
-        TTE_WHITE_PB,
-        s_reroll_cost
-    );
+    game_shop_display_reroll_cost();
 }
 
 /**
@@ -565,16 +582,20 @@ static void game_shop_process_user_input(void)
         case 0:
         {
             s_description_card_original_list = get_jokers_container()->contents;
-            tmp_card = list_get_at_idx(get_jokers_container()->contents, shop_selection_grid.selection.x);
+            tmp_card =
+                list_get_at_idx(get_jokers_container()->contents, shop_selection_grid.selection.x);
             break;
         }
 
         // Jokers for sale
         case 1:
         {
-            s_description_card_original_list = &s_shop_items_list;
+            s_description_card_original_list = s_shop_items_container.contents;
             tmp_card = (shop_selection_grid.selection.x > 0)
-                         ? list_get_at_idx(&s_shop_items_list, shop_selection_grid.selection.x - 1)
+                         ? list_get_at_idx(
+                               s_shop_items_container.contents,
+                               shop_selection_grid.selection.x - 1
+                           )
                          : NULL;
             break;
         }
@@ -630,7 +651,7 @@ static void game_shop_show_card_desc(void)
         }
 
         // Shop Jokers
-        itr = list_itr_create(&s_shop_items_list);
+        itr = list_itr_create(s_shop_items_container.contents);
         while ((joker_object = list_itr_next(&itr)))
         {
             if (joker_object != s_description_card)
@@ -748,7 +769,7 @@ static void game_shop_hide_card_desc(void)
         }
 
         // Shop Jokers
-        itr = list_itr_create(&s_shop_items_list);
+        itr = list_itr_create(s_shop_items_container.contents);
         while ((joker_object = list_itr_next(&itr)))
         {
             if (joker_object != s_description_card)
@@ -775,28 +796,21 @@ static void game_shop_hide_card_desc(void)
     else if (s_timer == s_show_description_anim_progress + 1)
     {
         // Need to account for the description_card being selected if it came from the shop.
-        if (s_description_card_original_list == &s_shop_items_list)
+        if (s_description_card_original_list == s_shop_items_container.contents)
             s_description_card->ty += int2fx(TILE_SIZE);
 
         // Print price under shop Jokers
         Item* item = NULL;
-        ListItr itr = list_itr_create(&s_shop_items_list);
+        ListItr itr = list_itr_create(s_shop_items_container.contents);
         while ((item = list_itr_next(&itr)))
         {
             item_print_buy_price_under(item);
         }
 
-        if (s_description_card_original_list == &s_shop_items_list)
+        if (s_description_card_original_list == s_shop_items_container.contents)
             s_description_card->ty -= int2fx(TILE_SIZE);
 
-        // Print Reroll prince
-        tte_printf(
-            "#{P:%d,%d; cx:0x%X000}$%d",
-            SHOP_REROLL_RECT.left,
-            SHOP_REROLL_RECT.top,
-            TTE_WHITE_PB,
-            s_reroll_cost
-        );
+        game_shop_display_reroll_cost();
 
         // Print Deck size that was erased
         display_deck_size_max();
@@ -839,7 +853,7 @@ static void game_shop_outro(void)
     {
         tte_erase_rect_wrapper(SHOP_PRICES_TEXT_RECT); // Erase the shop prices text
 
-        ListItr itr = list_itr_create(&s_shop_items_list);
+        ListItr itr = list_itr_create(s_shop_items_container.contents);
         SpriteObject* shop_item;
         while ((shop_item = list_itr_next(&itr)))
         {
@@ -908,7 +922,7 @@ void game_shop_on_update(void)
 
 void game_shop_on_exit(void)
 {
-    List* shop_items_list = &s_shop_items_list;
+    List* shop_items_list = s_shop_items_container.contents;
     ListItr itr = list_itr_create(shop_items_list);
     Item* item;
 

--- a/source/joker_effects.c
+++ b/source/joker_effects.c
@@ -385,7 +385,7 @@ static int stencil_joker_desc(Joker* joker, Rect dest_rect)
                     "X%ld " TTE_BLACK_TAG "Mult)";
     const u32 desc_max_size = 130;
 
-    List* jokers = get_jokers_list();
+    List* jokers = get_jokers_container()->contents;
     u32 stencil_bonus = MAX_JOKERS_HELD_SIZE - list_get_len(jokers);
 
     ListItr itr = list_itr_create(jokers);
@@ -514,7 +514,7 @@ static int abstract_joker_desc(Joker* joker, Rect dest_rect)
                     " card\n\n(Now " TTE_RED_TAG "+%ld" TTE_BLACK_TAG " Mult)";
     const u32 desc_max_size = 125;
 
-    u32 abstract_bonus = list_get_len(get_jokers_list()) * 3;
+    u32 abstract_bonus = list_get_len(get_jokers_container()->contents) * 3;
 
     char desc[desc_max_size];
     snprintf(desc, desc_max_size, desc_format, abstract_bonus);
@@ -1058,7 +1058,7 @@ static u32 stencil_joker_effect(
 
     *joker_effect = &s_shared_joker_effect;
 
-    List* jokers = get_jokers_list();
+    List* jokers = get_jokers_container()->contents;
 
     // +1 xmult per empty joker slot...
     int num_jokers = list_get_len(jokers);
@@ -1391,7 +1391,7 @@ static u32 abstract_joker_effect(
     *joker_effect = &s_shared_joker_effect;
 
     // +1 xmult per occupied joker slot
-    int num_jokers = list_get_len(get_jokers_list());
+    int num_jokers = list_get_len(get_jokers_container()->contents);
 
     (*joker_effect)->mult = num_jokers * 3;
 
@@ -1815,7 +1815,7 @@ static u32 blueprint_brainstorm_joker_effect(
     }
 
     // find ourselves in the Jokers list
-    List* jokers = get_jokers_list();
+    List* jokers = get_jokers_container()->contents;
     ListItr itr = list_itr_create(jokers);
     JokerObject* copied_joker_object;
     while ((copied_joker_object = list_itr_next(&itr)))

--- a/source/save.c
+++ b/source/save.c
@@ -352,7 +352,7 @@ void save_game(void)
 
     // Lists
 
-    List* jokers_list = get_jokers_list();
+    List* jokers_list = get_jokers_container()->contents;
     int nb_jokers = list_get_len(jokers_list);
 
     int i = 0;

--- a/source/sprite_container.c
+++ b/source/sprite_container.c
@@ -10,25 +10,24 @@ static inline void container_update(SpriteContainer* container)
 
     if (container->direction == LAYOUT_DIR_HORIZONTAL)
     {
-        pos_size.x = container->sprite_pos_size.left;
-        pos_size.y = container->sprite_pos_size.right;
+        pos_size.x = container->sprite_local_aabb.left;
+        pos_size.y = rect_width(&(container->sprite_local_aabb));
 
-        max_length = container->pos.right;
+        max_length = rect_width(&(container->pos));
         start_pos = container->pos.left;
     }
     else
     {
-        pos_size.x = container->sprite_pos_size.top;
-        pos_size.y = container->sprite_pos_size.bottom;
+        pos_size.x = container->sprite_local_aabb.top;
+        pos_size.y = rect_height(&(container->sprite_local_aabb));
 
-        max_length = container->pos.bottom;
+        max_length = rect_height(&(container->pos));
         start_pos = container->pos.top;
     }
 
     int nb_sprites = list_get_len(container->contents);
     int spacing = container->minimum_spacing;
-    int naive_length =
-        nb_sprites * pos_size.y + (nb_sprites - 1) * spacing;
+    int naive_length = nb_sprites * pos_size.y + (nb_sprites - 1) * spacing;
 
     int overrun = naive_length - max_length;
 
@@ -49,7 +48,8 @@ static inline void container_update(SpriteContainer* container)
 
     while ((sprite_object = list_itr_next(&itr)))
     {
-        FIXED* coord = (container->direction == LAYOUT_DIR_HORIZONTAL) ? &sprite_object->tx : &sprite_object->ty;
+        FIXED* coord = (container->direction == LAYOUT_DIR_HORIZONTAL) ? &sprite_object->tx
+                                                                       : &sprite_object->ty;
         *coord = int2fx(start_pos - pos_size.x);
 
         start_pos += pos_size.y + spacing;

--- a/source/sprite_container.c
+++ b/source/sprite_container.c
@@ -35,7 +35,17 @@ static inline void container_update(SpriteContainer* container)
     if (overrun > 0 && nb_sprites > 1)
     {
         // Ceil the reduction so the corrected layout does not still overflow.
-        spacing -= (overrun + (nb_sprites - 2)) / (nb_sprites - 1);
+        int reduce = (overrun + (nb_sprites - 2)) / (nb_sprites - 1);
+        spacing -= reduce;
+
+        // If the sprites need to be centered, and depending on the numer of them, the reduction to
+        // the spacing may cause an imbalance that can be solved by shifting the sprites slightly
+        // to the right
+        if (container->justification == LAYOUT_JUST_CENTER)
+        {
+            int new_length = nb_sprites * pos_size.y + (nb_sprites - 1) * spacing;
+            start_pos += (max_length - new_length) / 2;
+        }
     }
     // If they fit inside the container, correct the starting point if they need to be centered
     else if (overrun < 0 && container->justification == LAYOUT_JUST_CENTER)

--- a/source/sprite_container.c
+++ b/source/sprite_container.c
@@ -1,8 +1,8 @@
 #include "sprite_container.h"
 
-#include "sprite.h"
+#include "util.h"
 
-void layout_container_update(LayoutContainer* container)
+static inline void container_update(SpriteContainer* container)
 {
     POINT pos_size;
     int max_length;
@@ -54,4 +54,56 @@ void layout_container_update(LayoutContainer* container)
 
         start_pos += pos_size.y + spacing;
     }
+}
+
+void container_push_front(SpriteContainer* container, SpriteObject* sprite_object)
+{
+    GBAL_RETURN_IF_NULL_VOID(container);
+    list_push_front(container->contents, (void*)sprite_object);
+    container_update(container);
+}
+
+void container_push_back(SpriteContainer* container, SpriteObject* sprite_object)
+{
+    GBAL_RETURN_IF_NULL_VOID(container);
+    list_push_back(container->contents, (void*)sprite_object);
+    container_update(container);
+}
+
+void container_insert(SpriteContainer* container, SpriteObject* sprite_object, unsigned int idx)
+{
+    GBAL_RETURN_IF_NULL_VOID(container);
+    list_insert(container->contents, (void*)sprite_object, idx);
+    container_update(container);
+}
+
+bool container_swap(SpriteContainer* container, unsigned int idx_a, unsigned int idx_b)
+{
+    GBAL_RETURN_IF_NULL_RET(container, false);
+    bool res = list_swap(container->contents, idx_a, idx_b);
+    container_update(container);
+    return res;
+}
+
+bool container_remove_at_idx(SpriteContainer* container, unsigned int idx)
+{
+    GBAL_RETURN_IF_NULL_RET(container, false);
+    bool res = list_remove_at_idx(container->contents, idx);
+    container_update(container);
+    return res;
+}
+
+bool container_remove_data(SpriteContainer* container, SpriteObject* sprite_object)
+{
+    GBAL_RETURN_IF_NULL_RET(container, false);
+    bool res = list_remove_data(container->contents, (void*)sprite_object);
+    container_update(container);
+    return res;
+}
+
+void container_itr_remove_current_node(SpriteContainer* container, ListItr* itr)
+{
+    GBAL_RETURN_IF_NULL_VOID(container);
+    list_itr_remove_current_node(itr);
+    container_update(container);
 }

--- a/source/sprite_container.c
+++ b/source/sprite_container.c
@@ -32,15 +32,17 @@ static inline void container_update(SpriteContainer* container)
     int overrun = naive_length - max_length;
 
     // If sprites take too much space, correct the spacing
-    if (overrun > 0)
+    if (overrun > 0 && nb_sprites > 1)
     {
-        spacing -= overrun / (nb_sprites - 1);
+        // Ceil the reduction so the corrected layout does not still overflow.
+        spacing -= (overrun + (nb_sprites - 2)) / (nb_sprites - 1);
     }
     // If they fit inside the container, correct the starting point if they need to be centered
-    else if (container->justification == LAYOUT_JUST_CENTER)
+    else if (overrun < 0 && container->justification == LAYOUT_JUST_CENTER)
     {
         start_pos -= overrun / 2;
     }
+    // And don't do anything if the fit is perfect (overrun == 0)
 
     // Set sprite positions
     SpriteObject* sprite_object = NULL;

--- a/source/sprite_container.c
+++ b/source/sprite_container.c
@@ -1,0 +1,57 @@
+#include "sprite_container.h"
+
+#include "sprite.h"
+
+void layout_container_update(LayoutContainer* container)
+{
+    POINT pos_size;
+    int max_length;
+    int start_pos;
+
+    if (container->direction == LAYOUT_DIR_HORIZONTAL)
+    {
+        pos_size.x = container->sprite_pos_size.left;
+        pos_size.y = container->sprite_pos_size.right;
+
+        max_length = container->pos.right;
+        start_pos = container->pos.left;
+    }
+    else
+    {
+        pos_size.x = container->sprite_pos_size.top;
+        pos_size.y = container->sprite_pos_size.bottom;
+
+        max_length = container->pos.bottom;
+        start_pos = container->pos.top;
+    }
+
+    int nb_sprites = list_get_len(container->contents);
+    int spacing = container->minimum_spacing;
+    int naive_length =
+        nb_sprites * pos_size.y + (nb_sprites - 1) * spacing;
+
+    int overrun = naive_length - max_length;
+
+    // If sprites take too much space, correct the spacing
+    if (overrun > 0)
+    {
+        spacing -= overrun / (nb_sprites - 1);
+    }
+    // If they fit inside the container, correct the starting point if they need to be centered
+    else if (container->justification == LAYOUT_JUST_CENTER)
+    {
+        start_pos -= overrun / 2;
+    }
+
+    // Set sprite positions
+    SpriteObject* sprite_object = NULL;
+    ListItr itr = list_itr_create(container->contents);
+
+    while ((sprite_object = list_itr_next(&itr)))
+    {
+        FIXED* coord = (container->direction == LAYOUT_DIR_HORIZONTAL) ? &sprite_object->tx : &sprite_object->ty;
+        *coord = int2fx(start_pos - pos_size.x);
+
+        start_pos += pos_size.y + spacing;
+    }
+}


### PR DESCRIPTION
*May* close #596?

This only addresses the spacing aspect of the issue, I had already submitted the layering in a separate PR. The first PR to be merged will be rebased on to integrate both changes into the SpriteContainer's update logic.

Currently only Owned Jokers and Shop Items use the new Container. Skip Tags are still not here yet, and the Playing Cards still use C arrays. Maybe I'll take a look at migrating that to Lists once this whole feature is merged.

The new Container works by giving it a List of pointers that can be cast to SpriteObjects, a Rect size/position, some layout flags, a spacing and a bounding box representing the Sprite's *actual* area within the tiles in memory (which allows to be more accurate in determining when the sprites overflow the container and properly space them).

For instance, the Items (Jokers, Cards, Tarot etc) may technically be 32x32 px in memory, but we can also say that the actual art is generally 24x32 px, meaning that what I call the "local bounding box" would be `{4, 0, 28, 32}`.