### PR TITLE
[Enhancement] Enable Hold B joker descriptions during rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://github.com/user-attachments/assets/54a9e2e9-1a02-48d5-bb9d-5ab257a7e03b
 
 (Hold A + D-Pad: Move Cards and Jokers in Hand)
 
-(Hold B: Display Joker Description **_Shop Only_**)
+(Hold B: Display Joker Description on focused Joker)
 
 # Contributing
 

--- a/include/game/joker_desc.h
+++ b/include/game/joker_desc.h
@@ -1,0 +1,126 @@
+/**
+ * @file joker_desc.h
+ *
+ * @brief Shared Joker description overlay (panel draw + active card tracking).
+ */
+#ifndef GAME_JOKER_DESC_H
+#define GAME_JOKER_DESC_H
+
+#include "graphic_utils.h"
+#include "joker.h"
+
+#include <tonc.h>
+
+/** Frames to slide UI / joker into place when showing a description. */
+#define TM_SHOW_CARD_DESC_WAIT 12
+
+/** Frames near the end of the show anim used to tuck the deck away. */
+#define TM_HIDE_DECK_WAIT 5
+
+/** Pixel Y offset used to tuck owned jokers off the top while viewing a description. */
+#define JOKER_DESC_OWNED_HIDE_Y_OFFSET 50
+
+/** Palette indices for the description rarity stripe on the play BG.
+ *  Must not reuse 24-31 — those are the score-flame colors (blue/red). */
+#define JOKER_DESC_RARITY_MAIN_COLOR_PAL_IDX   32
+#define JOKER_DESC_RARITY_SHADOW_COLOR_PAL_IDX 33
+
+// clang-format off
+/** Destination rect for the description 9-patch (tiles) — shop and round. */
+static const Rect JOKER_DESC_9_PTCH_TO_RECT = { 9,  6, 28, 18};
+
+/** Text area inside the description panel (tiles). */
+static const Rect JOKER_DESC_TEXT_RECT = {11,  9, 26, 18};
+
+/** Name line at the top of the description panel (tiles). */
+static const Rect JOKER_DESC_NAME_TEXT_RECT = {10,  7, 27,  7};
+
+/** Screen position (pixels) for the joker sprite while its description is shown. */
+static const BG_POINT JOKER_DESC_SPRITE_POS = {135, 9};
+// clang-format on
+
+/**
+ * @brief Get the joker currently shown in a description overlay, if any.
+ *
+ * Used so movement loops do not fight the description animation.
+ */
+JokerObject* joker_desc_get_active(void);
+
+/**
+ * @brief Set which joker is currently shown in a description overlay (or NULL).
+ */
+void joker_desc_set_active(JokerObject* joker_object);
+
+/**
+ * @brief Install the shop's description 9-patch into the currently loaded play background.
+ *
+ * Copies tiles into free VRAM slots, stages source SE offscreen, and returns the source rect.
+ * Call @ref joker_desc_release_shop_9patch_se after expanding.
+ */
+const NinePatchRect* joker_desc_install_shop_9patch(void);
+
+/**
+ * @brief Copy shop 9-patch tiles into VRAM without leaving staged SE behind.
+ */
+void joker_desc_install_shop_9patch_tiles(void);
+
+/**
+ * @brief Restore atlas SE overwritten while staging the shop 9-patch source.
+ */
+void joker_desc_release_shop_9patch_se(void);
+
+/**
+ * @brief Save main-BG SE under @p se_rect before drawing the description overlay over it.
+ *
+ * @param se_rect Tile rect to preserve (must fit in the underlay buffer)
+ */
+void joker_desc_save_underlay(Rect se_rect);
+
+/**
+ * @brief Restore the SE saved by @ref joker_desc_save_underlay.
+ */
+void joker_desc_restore_underlay(void);
+
+/**
+ * @brief Discard any saved underlay without writing it back.
+ */
+void joker_desc_discard_underlay(void);
+
+/**
+ * @brief Clear an SE rect inclusively (unlike @c main_bg_se_clear_rect).
+ */
+void joker_desc_clear_se_rect(Rect se_rect);
+
+/**
+ * @brief Draw name, description text, rarity label, and the description panel (shop path).
+ *
+ * @param joker Joker whose registry entry supplies name/desc/rarity
+ * @param src_9_ptch 9-patch source tiles in the currently loaded background
+ * @param rarity_main_pal_idx Palette index overwritten with the rarity main color
+ * @param rarity_shadow_pal_idx Palette index overwritten with the rarity shadow color
+ */
+void joker_desc_draw_panel(
+    Joker* joker,
+    const NinePatchRect* src_9_ptch,
+    u8 rarity_main_pal_idx,
+    u8 rarity_shadow_pal_idx
+);
+
+/**
+ * @brief Draw the description panel during a round using installed shop 9-patch tiles.
+ */
+void joker_desc_draw_round_panel(Joker* joker, u8 rarity_main_pal_idx, u8 rarity_shadow_pal_idx);
+
+/**
+ * @brief Restore play-BG flame palette slots (24-31) from the stock play palette.
+ *
+ * Older rarity-stripe code overwrote 27/28 and left blue pixels in the red flame.
+ */
+void joker_desc_restore_flame_palette(void);
+
+/**
+ * @brief Clear the description panel tiles from the main background.
+ */
+void joker_desc_clear_panel(void);
+
+#endif // GAME_JOKER_DESC_H

--- a/include/game/joker_desc.h
+++ b/include/game/joker_desc.h
@@ -82,6 +82,19 @@ void joker_desc_save_underlay(Rect se_rect);
 void joker_desc_restore_underlay(void);
 
 /**
+ * @brief Restore saved underlay SE except cells inside @p exclude.
+ *
+ * Keeps the underlay buffer so later @ref joker_desc_restore_underlay_rect calls can
+ * heal regions (e.g. flame atlas under the deck) after a reversible scroll.
+ */
+void joker_desc_restore_underlay_except(Rect exclude);
+
+/**
+ * @brief Restore only the cells of @p only that fall inside the saved underlay rect.
+ */
+void joker_desc_restore_underlay_rect(Rect only);
+
+/**
  * @brief Discard any saved underlay without writing it back.
  */
 void joker_desc_discard_underlay(void);

--- a/include/layout.h
+++ b/include/layout.h
@@ -18,7 +18,10 @@ static const BG_POINT HELD_JOKERS_POS                  = {108,     10};
 // Rects                                                  left     top     right   bottom
 static const Rect TOP_LEFT_PANEL_ANIM_RECT             = {0,       0,      8,      4};
 static const Rect POP_MENU_ANIM_RECT                   = {9,       7,      24,     31};
-static const Rect DECK_ANIM_RECT                       = {25,      14,     28,     19}; // Deck is rows 14-18; +1 empty row so TM_HIDE_DECK_WAIT (5) leaves a peek. Row 20+ = play flame atlas — do not include.
+// Shop / blind-select: full deck strip (no flame atlas on those backgrounds).
+static const Rect DECK_ANIM_RECT                       = {25,      14,     28,     23};
+// Play round: shorter so TM_HIDE_DECK_WAIT peeks and we never scroll into flame tiles (row 20+).
+static const Rect PLAY_DECK_ANIM_RECT                  = {25,      14,     28,     19};
 static const Rect TOP_LEFT_ITEM_SRC_RECT               = {0,       20,     8,      25};
 static const Rect TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT = {0,       28,     8,      28};
 static const Rect BLIND_REWARD_RECT                    = {40,      32,     64,     40};

--- a/include/layout.h
+++ b/include/layout.h
@@ -20,8 +20,11 @@ static const Rect TOP_LEFT_PANEL_ANIM_RECT             = {0,       0,      8,   
 static const Rect POP_MENU_ANIM_RECT                   = {9,       7,      24,     31};
 // Shop / blind-select: full deck strip (no flame atlas on those backgrounds).
 static const Rect DECK_ANIM_RECT                       = {25,      14,     28,     23};
-// Play round: shorter so TM_HIDE_DECK_WAIT peeks and we never scroll into flame tiles (row 20+).
-static const Rect PLAY_DECK_ANIM_RECT                  = {25,      14,     28,     19};
+// Play round: same height as shop so TM_HIDE_DECK_WAIT downs are reversible inside the
+// rect. Rows 20-23 briefly overwrite flame-atlas SE; restore those from underlay after untuck.
+static const Rect PLAY_DECK_ANIM_RECT                  = {25,      14,     28,     23};
+// Flame tile sources under the play deck columns — heal after deck tuck/untuck.
+static const Rect PLAY_DECK_FLAME_SE_RECT              = {25,      20,     28,     23};
 static const Rect TOP_LEFT_ITEM_SRC_RECT               = {0,       20,     8,      25};
 static const Rect TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT = {0,       28,     8,      28};
 static const Rect BLIND_REWARD_RECT                    = {40,      32,     64,     40};

--- a/include/layout.h
+++ b/include/layout.h
@@ -18,7 +18,7 @@ static const BG_POINT HELD_JOKERS_POS                  = {108,     10};
 // Rects                                                  left     top     right   bottom
 static const Rect TOP_LEFT_PANEL_ANIM_RECT             = {0,       0,      8,      4};
 static const Rect POP_MENU_ANIM_RECT                   = {9,       7,      24,     31};
-static const Rect DECK_ANIM_RECT                       = {25,      14,     28,     23}; // Can be used for the Shop and Blind Select screen
+static const Rect DECK_ANIM_RECT                       = {25,      14,     28,     19}; // Deck is rows 14-18; +1 empty row so TM_HIDE_DECK_WAIT (5) leaves a peek. Row 20+ = play flame atlas — do not include.
 static const Rect TOP_LEFT_ITEM_SRC_RECT               = {0,       20,     8,      25};
 static const Rect TOP_LEFT_PANEL_BOTTOM_ROW_RESET_RECT = {0,       28,     8,      28};
 static const Rect BLIND_REWARD_RECT                    = {40,      32,     64,     40};

--- a/source/game.c
+++ b/source/game.c
@@ -9,6 +9,7 @@
 #include "game/blind_select.h"
 #include "game/common_ui.h"
 #include "game/game_over.h"
+#include "game/joker_desc.h"
 #include "game/joker_row.h"
 #include "game/main_menu.h"
 #include "game/options_menu.h"
@@ -277,8 +278,8 @@ static inline void held_jokers_update_loop(void)
     int i = 0;
     while ((joker = list_itr_next(&itr)))
     {
-        // Let the Shop handle the position of this Joker
-        if (joker != game_shop_get_description_card())
+        // Let description overlay handle this Joker's position
+        if (joker != joker_desc_get_active())
             joker->tx = hand_x - int2fx(SPACING_LUT[jokers_top][i]);
         i++;
     }

--- a/source/game/joker_desc.c
+++ b/source/game/joker_desc.c
@@ -1,0 +1,285 @@
+/**
+ * @file joker_desc.c
+ *
+ * @brief Shared Joker description overlay implementation.
+ */
+
+#include "game/joker_desc.h"
+
+#include "background_gfx.h"
+#include "background_shop_gfx.h"
+#include "util.h"
+
+#include <string.h>
+
+// Shop 9-patch lives in the offscreen bank of background_shop_gfx
+#define SHOP_DESC_9_PTCH_X 27
+#define SHOP_DESC_9_PTCH_Y 25
+#define DESC_9_PTCH_W      5
+#define DESC_9_PTCH_H      7
+
+// Play background uses tiles 0-204; free charblock tail starts at 205
+#define ROUND_DESC_TILE_BASE 205
+
+// Stage the remapped 5x7 source in the play atlas offscreen bank (same idea as shop)
+#define ROUND_DESC_SRC_SE_X 0
+#define ROUND_DESC_SRC_SE_Y 25
+
+#define TILE8_BYTES           64
+#define PANEL_UNDERLAY_MAX_SE (20 * 32)
+#define STAGE_SE_COUNT        (DESC_9_PTCH_W * DESC_9_PTCH_H)
+
+static JokerObject* s_active_joker = NULL;
+
+static bool s_underlay_saved = false;
+static EWRAM_BSS u16 s_panel_underlay_se[PANEL_UNDERLAY_MAX_SE];
+static Rect s_panel_underlay_rect;
+
+static EWRAM_BSS u16 s_stage_se_backup[STAGE_SE_COUNT];
+static bool s_stage_se_saved = false;
+
+static const NinePatchRect s_round_desc_9_ptch_src = {
+    .patch_rect =
+        {ROUND_DESC_SRC_SE_X,
+         ROUND_DESC_SRC_SE_Y,
+         ROUND_DESC_SRC_SE_X + DESC_9_PTCH_W - 1,
+         ROUND_DESC_SRC_SE_Y + DESC_9_PTCH_H - 1},
+    .margins = {2, 3, 2, 3},
+};
+
+JokerObject* joker_desc_get_active(void)
+{
+    return s_active_joker;
+}
+
+void joker_desc_set_active(JokerObject* joker_object)
+{
+    s_active_joker = joker_object;
+}
+
+static u8 shop_pal_index_to_play(u8 shop_idx)
+{
+    switch (shop_idx)
+    {
+        // Keep 0 transparent: remapping it to opaque buries the outer white rim
+        // inside dark chrome and reads as a clipped vertical white strip.
+        case 13:
+            return 15; // white
+        case 19:
+            return 10; // dark gray fill
+        case 25:
+            return 20; // light gray
+        // Shop uses 27/28 as rarity-stripe placeholders; play 27/28 are flame colors.
+        case 27:
+            return JOKER_DESC_RARITY_MAIN_COLOR_PAL_IDX;
+        case 28:
+            return JOKER_DESC_RARITY_SHADOW_COLOR_PAL_IDX;
+        default:
+            return shop_idx;
+    }
+}
+
+static inline u16 patch_tid(int dx, int dy)
+{
+    return (u16)(ROUND_DESC_TILE_BASE + dy * DESC_9_PTCH_W + dx);
+}
+
+/** Shop atlas reuses left-edge tiles on the right with SE_HFLIP — preserve those flags. */
+static inline u16 patch_se(int dx, int dy)
+{
+    int shop_map_idx = (SHOP_DESC_9_PTCH_Y + dy) * SE_ROW_LEN + (SHOP_DESC_9_PTCH_X + dx);
+    u16 shop_se = background_shop_gfxMap[shop_map_idx];
+    return (u16)(patch_tid(dx, dy) | (shop_se & (SE_HFLIP | SE_VFLIP)));
+}
+
+void joker_desc_install_shop_9patch_tiles(void)
+{
+    for (int dy = 0; dy < DESC_9_PTCH_H; dy++)
+    {
+        for (int dx = 0; dx < DESC_9_PTCH_W; dx++)
+        {
+            int shop_map_idx =
+                (SHOP_DESC_9_PTCH_Y + dy) * SE_ROW_LEN + (SHOP_DESC_9_PTCH_X + dx);
+            int shop_tid = background_shop_gfxMap[shop_map_idx] & 0x03FF;
+            int dest_tid = ROUND_DESC_TILE_BASE + dy * DESC_9_PTCH_W + dx;
+            const u8* src = (const u8*)background_shop_gfxTiles + shop_tid * TILE8_BYTES;
+
+            u16 remapped[TILE8_BYTES / 2];
+            for (int i = 0; i < TILE8_BYTES; i += 2)
+            {
+                u8 lo = shop_pal_index_to_play(src[i]);
+                u8 hi = shop_pal_index_to_play(src[i + 1]);
+                remapped[i / 2] = (u16)(lo | (hi << 8));
+            }
+            memcpy16(&tile8_mem[MAIN_BG_CBB][dest_tid], remapped, TILE8_BYTES / 2);
+        }
+    }
+}
+
+static void stage_round_9patch_se(void)
+{
+    int i = 0;
+    for (int dy = 0; dy < DESC_9_PTCH_H; dy++)
+    {
+        for (int dx = 0; dx < DESC_9_PTCH_W; dx++)
+        {
+            s_stage_se_backup[i++] =
+                se_mat[MAIN_BG_SBB][ROUND_DESC_SRC_SE_Y + dy][ROUND_DESC_SRC_SE_X + dx];
+            se_mat[MAIN_BG_SBB][ROUND_DESC_SRC_SE_Y + dy][ROUND_DESC_SRC_SE_X + dx] =
+                patch_se(dx, dy);
+        }
+    }
+    s_stage_se_saved = true;
+}
+
+static void restore_round_9patch_se(void)
+{
+    if (!s_stage_se_saved)
+        return;
+
+    int i = 0;
+    for (int dy = 0; dy < DESC_9_PTCH_H; dy++)
+    {
+        for (int dx = 0; dx < DESC_9_PTCH_W; dx++)
+            se_mat[MAIN_BG_SBB][ROUND_DESC_SRC_SE_Y + dy][ROUND_DESC_SRC_SE_X + dx] =
+                s_stage_se_backup[i++];
+    }
+    s_stage_se_saved = false;
+}
+
+const NinePatchRect* joker_desc_install_shop_9patch(void)
+{
+    joker_desc_install_shop_9patch_tiles();
+    stage_round_9patch_se();
+    return &s_round_desc_9_ptch_src;
+}
+
+void joker_desc_release_shop_9patch_se(void)
+{
+    restore_round_9patch_se();
+}
+
+void joker_desc_save_underlay(Rect se_rect)
+{
+    s_panel_underlay_rect = se_rect;
+    int i = 0;
+
+    for (int y = s_panel_underlay_rect.top; y <= s_panel_underlay_rect.bottom; y++)
+    {
+        for (int x = s_panel_underlay_rect.left; x <= s_panel_underlay_rect.right; x++)
+        {
+            if (i < PANEL_UNDERLAY_MAX_SE)
+                s_panel_underlay_se[i++] = se_mat[MAIN_BG_SBB][y][x];
+        }
+    }
+
+    s_underlay_saved = true;
+}
+
+void joker_desc_restore_underlay(void)
+{
+    if (!s_underlay_saved)
+        return;
+
+    int i = 0;
+    for (int y = s_panel_underlay_rect.top; y <= s_panel_underlay_rect.bottom; y++)
+    {
+        for (int x = s_panel_underlay_rect.left; x <= s_panel_underlay_rect.right; x++)
+        {
+            if (i < PANEL_UNDERLAY_MAX_SE)
+                se_mat[MAIN_BG_SBB][y][x] = s_panel_underlay_se[i++];
+        }
+    }
+
+    s_underlay_saved = false;
+}
+
+void joker_desc_discard_underlay(void)
+{
+    s_underlay_saved = false;
+}
+
+void joker_desc_clear_se_rect(Rect se_rect)
+{
+    for (int y = se_rect.top; y <= se_rect.bottom; y++)
+    {
+        if (y < 0 || y >= 32)
+            continue;
+        int left = se_rect.left < 0 ? 0 : se_rect.left;
+        int right = se_rect.right > 31 ? 31 : se_rect.right;
+        if (left > right)
+            continue;
+        memset16(&se_mat[MAIN_BG_SBB][y][left], 0, right - left + 1);
+    }
+}
+
+void joker_desc_draw_panel(
+    Joker* joker,
+    const NinePatchRect* src_9_ptch,
+    u8 rarity_main_pal_idx,
+    u8 rarity_shadow_pal_idx
+)
+{
+    GBAL_RETURN_IF_NULL_VOID(joker);
+    GBAL_RETURN_IF_NULL_VOID(src_9_ptch);
+
+    const JokerInfo* info = get_joker_registry_entry(joker->id);
+    GBAL_RETURN_IF_NULL_VOID(info);
+    GBAL_RETURN_IF_NULL_VOID(info->joker_print_desc);
+
+    const char* rarity_str = joker_get_rarity_string(info->rarity);
+    if (rarity_str == NULL)
+        rarity_str = "";
+
+    int max_text_height = rect_height(&JOKER_DESC_9_PTCH_TO_RECT) - src_9_ptch->margins.top -
+                          src_9_ptch->margins.bottom;
+    int lines_used = info->joker_print_desc(joker, JOKER_DESC_TEXT_RECT);
+    int desc_bottom_offset = max_text_height - lines_used;
+    if (desc_bottom_offset < 0)
+        desc_bottom_offset = 0;
+
+    tte_printf(
+        TTE_WHITE_TAG "#{P:%d,%d}%*s%s",
+        JOKER_DESC_TEXT_RECT.left * TILE_SIZE,
+        (JOKER_DESC_TEXT_RECT.bottom - desc_bottom_offset - 1) * TILE_SIZE,
+        (rect_width(&JOKER_DESC_TEXT_RECT) - (int)strlen(rarity_str)) / 2,
+        "",
+        rarity_str
+    );
+    pal_bg_mem[rarity_main_pal_idx] = joker_get_rarity_color(info->rarity, true);
+    pal_bg_mem[rarity_shadow_pal_idx] = joker_get_rarity_color(info->rarity, false);
+
+    Rect actual_dest_rect = JOKER_DESC_9_PTCH_TO_RECT;
+    actual_dest_rect.bottom -= desc_bottom_offset;
+    main_bg_se_copy_expand_9_patch(actual_dest_rect, src_9_ptch);
+
+    tte_printf(
+        TTE_WHITE_TAG "#{P:%d,%d}%*s%s",
+        JOKER_DESC_NAME_TEXT_RECT.left * TILE_SIZE,
+        JOKER_DESC_NAME_TEXT_RECT.top * TILE_SIZE,
+        (rect_width(&JOKER_DESC_NAME_TEXT_RECT) - (int)strlen(info->name)) / 2,
+        "",
+        info->name
+    );
+}
+
+void joker_desc_draw_round_panel(Joker* joker, u8 rarity_main_pal_idx, u8 rarity_shadow_pal_idx)
+{
+    // Same dest/text rects and 9-patch expand as the shop (via staged remapped tiles).
+    const NinePatchRect* src = joker_desc_install_shop_9patch();
+    joker_desc_draw_panel(joker, src, rarity_main_pal_idx, rarity_shadow_pal_idx);
+    joker_desc_release_shop_9patch_se();
+}
+
+/** Heal score-flame colors if an older desc path overwrote pal slots 27/28. */
+void joker_desc_restore_flame_palette(void)
+{
+    // Flame anim uses play-pal indices 24-31; 27/28 were previously reused for rarity.
+    for (int i = 24; i <= 31; i++)
+        pal_bg_mem[i] = background_gfxPal[i];
+}
+
+void joker_desc_clear_panel(void)
+{
+    joker_desc_clear_se_rect(JOKER_DESC_9_PTCH_TO_RECT);
+}

--- a/source/game/joker_desc.c
+++ b/source/game/joker_desc.c
@@ -194,6 +194,49 @@ void joker_desc_restore_underlay(void)
     s_underlay_saved = false;
 }
 
+static inline bool rect_contains_xy(Rect r, int x, int y)
+{
+    return x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+}
+
+void joker_desc_restore_underlay_except(Rect exclude)
+{
+    if (!s_underlay_saved)
+        return;
+
+    int i = 0;
+    for (int y = s_panel_underlay_rect.top; y <= s_panel_underlay_rect.bottom; y++)
+    {
+        for (int x = s_panel_underlay_rect.left; x <= s_panel_underlay_rect.right; x++)
+        {
+            if (i >= PANEL_UNDERLAY_MAX_SE)
+                return;
+            u16 se = s_panel_underlay_se[i++];
+            if (!rect_contains_xy(exclude, x, y))
+                se_mat[MAIN_BG_SBB][y][x] = se;
+        }
+    }
+}
+
+void joker_desc_restore_underlay_rect(Rect only)
+{
+    if (!s_underlay_saved)
+        return;
+
+    int i = 0;
+    for (int y = s_panel_underlay_rect.top; y <= s_panel_underlay_rect.bottom; y++)
+    {
+        for (int x = s_panel_underlay_rect.left; x <= s_panel_underlay_rect.right; x++)
+        {
+            if (i >= PANEL_UNDERLAY_MAX_SE)
+                return;
+            u16 se = s_panel_underlay_se[i++];
+            if (rect_contains_xy(only, x, y))
+                se_mat[MAIN_BG_SBB][y][x] = se;
+        }
+    }
+}
+
 void joker_desc_discard_underlay(void)
 {
     s_underlay_saved = false;

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -254,6 +254,8 @@ enum RoundDescState
 static enum RoundDescState s_round_desc_state = ROUND_DESC_IDLE;
 static int s_desc_timer = TM_ZERO;
 static int s_show_description_anim_progress = 0;
+static int s_deck_tuck_frames = 0;
+static int s_deck_untuck_remaining = 0;
 static FIXED s_description_card_original_x_pos = UNDEFINED;
 static FIXED s_description_card_original_y_pos = UNDEFINED;
 
@@ -261,7 +263,7 @@ static FIXED s_description_card_original_y_pos = UNDEFINED;
 static const Rect ROUND_DESC_UNDERLAY_RECT = {9, 0, 28, 31};
 static const Rect ROUND_DESC_JOKER_TRAY_RECT = {9, 1, 28, 5};
 // Same width as shop POP_MENU_ANIM_RECT — leave the deck (cols 25-28) alone so
-// DECK_ANIM_RECT can tuck it only partially (TM_HIDE_DECK_WAIT frames), like the shop.
+// PLAY_DECK_ANIM_RECT can tuck it only partially (TM_HIDE_DECK_WAIT frames), like the shop.
 static const Rect ROUND_DESC_BOTTOM_UI_RECT = {9, 7, 24, 31};
 
 static void game_round_desc_restore_hand_select_windows(void)
@@ -289,6 +291,8 @@ static void game_round_show_joker_desc(void)
     if (s_desc_timer == 1)
     {
         s_show_description_anim_progress = 0;
+        s_deck_tuck_frames = 0;
+        s_deck_untuck_remaining = 0;
 
         tte_erase_rect_wrapper(PLAYING_SCREEN_RECT);
 
@@ -300,7 +304,7 @@ static void game_round_show_joker_desc(void)
         game_round_desc_restore_hand_select_windows();
 
         // Hide the near-black hand-tray fill immediately (scroll alone takes several frames).
-        // Stop at col 24 so the deck (25-28) is only partially tucked via DECK_ANIM_RECT.
+        // Stop at col 24 so the deck (25-28) is only partially tucked via PLAY_DECK_ANIM_RECT.
         joker_desc_clear_se_rect((Rect){9, 11, 24, 20});
 
         sprite_object_erase_text_under((SpriteObject*)description_card);
@@ -325,7 +329,10 @@ static void game_round_show_joker_desc(void)
         main_bg_se_move_rect_1_tile_vert(ROUND_DESC_BOTTOM_UI_RECT, SCREEN_DOWN);
         main_bg_se_move_rect_1_tile_vert(ROUND_DESC_JOKER_TRAY_RECT, SCREEN_UP);
         if (TM_SHOW_CARD_DESC_WAIT - s_desc_timer < TM_HIDE_DECK_WAIT)
-            main_bg_se_move_rect_1_tile_vert(DECK_ANIM_RECT, SCREEN_DOWN);
+        {
+            main_bg_se_move_rect_1_tile_vert(PLAY_DECK_ANIM_RECT, SCREEN_DOWN);
+            s_deck_tuck_frames++;
+        }
     }
     else if (s_desc_timer == TM_SHOW_CARD_DESC_WAIT + 1)
     {
@@ -353,6 +360,8 @@ static void game_round_hide_joker_desc(void)
     {
         joker_desc_restore_underlay();
         game_round_desc_restore_hand_select_windows();
+        s_deck_tuck_frames = 0;
+        s_deck_untuck_remaining = 0;
         s_round_desc_state = ROUND_DESC_IDLE;
         s_desc_timer = TM_ZERO;
         return;
@@ -367,11 +376,13 @@ static void game_round_hide_joker_desc(void)
         tte_erase_rect_wrapper(PLAYING_SCREEN_RECT);
         game_round_desc_restore_hand_select_windows();
 
-        // Full SE restore (tray, buttons, deck). Do not re-tuck/scroll the deck:
-        // scrolling DECK_ANIM after restore discards tiles past the rect bottom
-        // and left the deck permanently clipped.
+        // Restore trays/buttons/deck SE, then re-tuck the deck in the same frame so the
+        // next frames can scroll it back up like the shop (no visible snap, no clip).
         joker_desc_restore_underlay();
         joker_desc_restore_flame_palette();
+        for (int i = 0; i < s_deck_tuck_frames; i++)
+            main_bg_se_move_rect_1_tile_vert(PLAY_DECK_ANIM_RECT, SCREEN_DOWN);
+        s_deck_untuck_remaining = s_deck_tuck_frames;
 
         display_deck_size_max();
         tte_printf(
@@ -394,20 +405,30 @@ static void game_round_hide_joker_desc(void)
         description_card->tx = s_description_card_original_x_pos;
         description_card->ty = s_description_card_original_y_pos;
     }
-    else if (description_card->vx == 0 && description_card->vy == 0)
+    else
     {
-        owned_joker_price_printed = false;
-        joker_desc_set_active(NULL);
-        s_desc_timer = TM_ZERO;
-        s_round_desc_state = ROUND_DESC_IDLE;
-    }
-    else if (!owned_joker_price_printed && !key_held(SELECT_CARD))
-    {
-        owned_joker_price_printed = true;
-        sprite_object_print_price_under(
-            (SpriteObject*)description_card,
-            joker_get_sell_value(description_card->joker)
-        );
+        if (s_deck_untuck_remaining > 0)
+        {
+            main_bg_se_move_rect_1_tile_vert(PLAY_DECK_ANIM_RECT, SCREEN_UP);
+            s_deck_untuck_remaining--;
+        }
+
+        if (description_card->vx == 0 && description_card->vy == 0 && s_deck_untuck_remaining == 0)
+        {
+            owned_joker_price_printed = false;
+            joker_desc_set_active(NULL);
+            s_deck_tuck_frames = 0;
+            s_desc_timer = TM_ZERO;
+            s_round_desc_state = ROUND_DESC_IDLE;
+        }
+        else if (!owned_joker_price_printed && !key_held(SELECT_CARD))
+        {
+            owned_joker_price_printed = true;
+            sprite_object_print_price_under(
+                (SpriteObject*)description_card,
+                joker_get_sell_value(description_card->joker)
+            );
+        }
     }
 }
 
@@ -915,6 +936,8 @@ static inline void game_round_process_hand_select_input(void)
     s_description_card_original_x_pos = focused->x;
     s_description_card_original_y_pos = focused->y;
     s_desc_timer = TM_ZERO;
+    s_deck_tuck_frames = 0;
+    s_deck_untuck_remaining = 0;
     s_round_desc_state = ROUND_DESC_SHOWING;
 }
 
@@ -1515,10 +1538,10 @@ static inline void cards_in_hand_update_loop(void)
                         hand_y -= int2fx(CARD_FOCUSED_SEL_Y);
                     }
                     // Unfocused cards that sit slightly below their rest y (after losing focus
-                    // raise) snap down. Do NOT snap large gaps — e.g. returning from the
-                    // description hide position — or they teleport instead of animating.
-                    if (i != selected_card_idx && hand[i]->y > hand_y &&
-                        hand[i]->y - hand_y <= int2fx(CARD_FOCUSED_SEL_Y))
+                    // raise) snap down. Skip while returning from the joker description so every
+                    // card spring-lerps back instead of a mixed snap/bounce.
+                    if (s_round_desc_state != ROUND_DESC_HIDING && i != selected_card_idx &&
+                        hand[i]->y > hand_y && hand[i]->y - hand_y <= int2fx(CARD_FOCUSED_SEL_Y))
                     {
                         hand[i]->y = hand_y;
                         // Set target y to match y. Ensures target is updated even when vy becomes

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -9,6 +9,7 @@
 #include "background_gfx.h"
 #include "button.h"
 #include "game.h"
+#include "game/joker_desc.h"
 #include "game/joker_row.h"
 #include "graphic_utils.h"
 #include "hand.h"
@@ -50,13 +51,18 @@
 #define NUM_SCORE_LERP_STEPS   16
 #define TM_SCORE_LERP_INTERVAL 2
 
-#define GAME_PLAYING_HAND_SEL_Y 1
+#define GAME_PLAYING_HAND_SEL_Y   1
+#define GAME_PLAYING_JOKERS_SEL_Y 0
 
+// Palette indices reserved for the description rarity stripe (offscreen-only in background_gfx)
 // Pixel sizes
 #define CARD_FOCUSED_UNSEL_Y 10
 #define CARD_UNFOCUSED_SEL_Y 15
 #define CARD_FOCUSED_SEL_Y   20
 #define SCORED_CARD_TEXT_Y   48
+// Peek at the bottom while the joker desc is open (not fully off-screen like 200).
+// Screen is 160px; leave ~half a card visible below the desc panel.
+#define HAND_CARDS_HIDE_Y    (160 - CARD_SPRITE_SIZE / 2)
 
 // clang-format off
 
@@ -97,6 +103,7 @@ static const BG_POINT CARD_DRAW_POS              = {208,     110};
 static const BG_POINT CARD_DISCARD_PNT           = {240,     70};
 static const BG_POINT HAND_START_POS             = {120,     90};
 static const BG_POINT HAND_PLAY_POS              = {120,     70};
+
 // clang-format on
 
 /*******************************************************************************
@@ -236,6 +243,174 @@ static bool s_discarded_card = false;
 static int s_cards_drawn = 0;
 static int s_cards_discarded = 0;
 
+// Joker description overlay (Hold B on the jokers row)
+enum RoundDescState
+{
+    ROUND_DESC_IDLE,
+    ROUND_DESC_SHOWING,
+    ROUND_DESC_HIDING
+};
+
+static enum RoundDescState s_round_desc_state = ROUND_DESC_IDLE;
+static int s_desc_timer = TM_ZERO;
+static int s_show_description_anim_progress = 0;
+static FIXED s_description_card_original_x_pos = UNDEFINED;
+static FIXED s_description_card_original_y_pos = UNDEFINED;
+
+// Joker tray + hand/buttons band scrolled or painted over while the desc is open
+static const Rect ROUND_DESC_UNDERLAY_RECT = {9, 0, 28, 31};
+static const Rect ROUND_DESC_JOKER_TRAY_RECT = {9, 1, 28, 5};
+// Same width as shop POP_MENU_ANIM_RECT — leave the deck (cols 25-28) alone so
+// DECK_ANIM_RECT can tuck it only partially (TM_HIDE_DECK_WAIT frames), like the shop.
+static const Rect ROUND_DESC_BOTTOM_UI_RECT = {9, 7, 24, 31};
+
+static void game_round_desc_restore_hand_select_windows(void)
+{
+    // Match selecting: blend tray only; keep Play/Discard (y>=128) outside WIN0.
+    REG_WIN0H = (72 << 8) | 200;
+    REG_WIN0V = (44 << 8) | 128;
+    REG_WIN0CNT = WIN_ALL | WIN_BLD;
+    toggle_windows(true, true);
+}
+
+static void game_round_show_joker_desc(void)
+{
+    JokerObject* description_card = joker_desc_get_active();
+    if (description_card == NULL || description_card->joker == NULL)
+    {
+        joker_desc_discard_underlay();
+        s_round_desc_state = ROUND_DESC_IDLE;
+        s_desc_timer = TM_ZERO;
+        return;
+    }
+
+    s_desc_timer++;
+
+    if (s_desc_timer == 1)
+    {
+        s_show_description_anim_progress = 0;
+
+        tte_erase_rect_wrapper(PLAYING_SCREEN_RECT);
+
+        // Snapshot SE before we scroll trays/buttons away or paint the panel
+        joker_desc_save_underlay(ROUND_DESC_UNDERLAY_RECT);
+
+        // Keep play blend while the tray slides away so it never flashes solid black.
+        // WIN0 is killed only when the opaque desc panel is drawn (below).
+        game_round_desc_restore_hand_select_windows();
+
+        // Hide the near-black hand-tray fill immediately (scroll alone takes several frames).
+        // Stop at col 24 so the deck (25-28) is only partially tucked via DECK_ANIM_RECT.
+        joker_desc_clear_se_rect((Rect){9, 11, 24, 20});
+
+        sprite_object_erase_text_under((SpriteObject*)description_card);
+
+        JokerObject* joker_object = NULL;
+        ListItr itr = list_itr_create(get_jokers_list());
+        while ((joker_object = list_itr_next(&itr)))
+        {
+            if (joker_object != description_card)
+                joker_object->ty -= int2fx(JOKER_DESC_OWNED_HIDE_Y_OFFSET);
+        }
+
+        description_card->tx = int2fx(JOKER_DESC_SPRITE_POS.x);
+        description_card->ty = int2fx(JOKER_DESC_SPRITE_POS.y);
+    }
+
+    if (s_desc_timer <= TM_SHOW_CARD_DESC_WAIT)
+    {
+        s_show_description_anim_progress++;
+
+        // Slide remaining bottom UI / joker tray chrome off-screen (shop-style)
+        main_bg_se_move_rect_1_tile_vert(ROUND_DESC_BOTTOM_UI_RECT, SCREEN_DOWN);
+        main_bg_se_move_rect_1_tile_vert(ROUND_DESC_JOKER_TRAY_RECT, SCREEN_UP);
+        if (TM_SHOW_CARD_DESC_WAIT - s_desc_timer < TM_HIDE_DECK_WAIT)
+            main_bg_se_move_rect_1_tile_vert(DECK_ANIM_RECT, SCREEN_DOWN);
+    }
+    else if (s_desc_timer == TM_SHOW_CARD_DESC_WAIT + 1)
+    {
+        // Opaque panel: same as shop. Tray is already gone, so no black flash.
+        toggle_windows(false, true);
+        joker_desc_draw_round_panel(
+            description_card->joker,
+            JOKER_DESC_RARITY_MAIN_COLOR_PAL_IDX,
+            JOKER_DESC_RARITY_SHADOW_COLOR_PAL_IDX
+        );
+    }
+
+    if (!key_held(DESELECT_CARDS))
+    {
+        s_desc_timer = TM_ZERO;
+        s_round_desc_state = ROUND_DESC_HIDING;
+    }
+}
+
+static void game_round_hide_joker_desc(void)
+{
+    static bool owned_joker_price_printed = false;
+    JokerObject* description_card = joker_desc_get_active();
+    if (description_card == NULL)
+    {
+        joker_desc_restore_underlay();
+        game_round_desc_restore_hand_select_windows();
+        s_round_desc_state = ROUND_DESC_IDLE;
+        s_desc_timer = TM_ZERO;
+        return;
+    }
+
+    s_desc_timer++;
+
+    if (s_desc_timer == 1)
+    {
+        owned_joker_price_printed = false;
+
+        tte_erase_rect_wrapper(PLAYING_SCREEN_RECT);
+        game_round_desc_restore_hand_select_windows();
+
+        // Full SE restore (tray, buttons, deck). Do not re-tuck/scroll the deck:
+        // scrolling DECK_ANIM after restore discards tiles past the rect bottom
+        // and left the deck permanently clipped.
+        joker_desc_restore_underlay();
+        joker_desc_restore_flame_palette();
+
+        display_deck_size_max();
+        tte_printf(
+            "#{P:%d,%d; cx:0x%X000}%2d/%-2ld",
+            HAND_SIZE_RECT_SELECT.left,
+            HAND_SIZE_RECT_SELECT.top,
+            TTE_WHITE_PB,
+            hand_nb_held_cards(),
+            g_game_vars.hand_size
+        );
+
+        JokerObject* joker_object = NULL;
+        ListItr itr = list_itr_create(get_jokers_list());
+        while ((joker_object = list_itr_next(&itr)))
+        {
+            if (joker_object != description_card)
+                joker_object->ty = int2fx(HELD_JOKERS_POS.y);
+        }
+
+        description_card->tx = s_description_card_original_x_pos;
+        description_card->ty = s_description_card_original_y_pos;
+    }
+    else if (description_card->vx == 0 && description_card->vy == 0)
+    {
+        owned_joker_price_printed = false;
+        joker_desc_set_active(NULL);
+        s_desc_timer = TM_ZERO;
+        s_round_desc_state = ROUND_DESC_IDLE;
+    }
+    else if (!owned_joker_price_printed && !key_held(SELECT_CARD))
+    {
+        owned_joker_price_printed = true;
+        sprite_object_print_price_under(
+            (SpriteObject*)description_card,
+            joker_get_sell_value(description_card->joker)
+        );
+    }
+}
+
 /*******************************************************************************
  * UTILS FUNCTIONS
  ******************************************************************************/
@@ -338,7 +513,13 @@ static void get_played_distribution(u8 ranks_out[NUM_RANKS], u8 suits_out[NUM_SU
 void game_round_change_background_selecting(void)
 {
     tte_erase_rect_wrapper(HAND_SIZE_RECT_PLAYING);
-    REG_WIN0V = (REG_WIN0V << 8) | 0x80; // Set window 0 top to 128
+
+    // Blend only the hand-tray fill (y 44-128). Buttons sit at y>=128 and must
+    // stay outside WIN0 — inside it BLDA makes BG1 weight 0 so they vanish into
+    // the affine BG (looks like empty transparent tray).
+    REG_WIN0H = (72 << 8) | 200;
+    REG_WIN0V = (44 << 8) | 128;
+    REG_WIN0CNT = WIN_ALL | WIN_BLD;
 
     if (get_current_background() == BG_CARD_PLAYING)
     {
@@ -348,6 +529,7 @@ void game_round_change_background_selecting(void)
             &background_gfxMap[SE_ROW_LEN * offset],
             SE_ROW_LEN * 8
         );
+        toggle_windows(true, true);
     }
     else
     {
@@ -404,7 +586,10 @@ void game_round_change_background_playing(void)
         change_background(BG_CARD_SELECTING, false);
     }
 
-    REG_WIN0V = (REG_WIN0V << 8) | 0xA0; // Set window 0 bottom to 160
+    // Hand tray moves down 3 tiles (y 112-160). Top must be <=112 or the upper
+    // half renders as solid near-black without blend (seen on the first played hand).
+    REG_WIN0H = (72 << 8) | 200;
+    REG_WIN0V = (112 << 8) | 160;
     toggle_windows(true, true);
 
     for (int i = 0; i <= 2; i++)
@@ -714,6 +899,23 @@ static inline int hand_sel_idx_to_card_idx(int selection_index)
 static inline void game_round_process_hand_select_input(void)
 {
     selection_grid_process_input(&game_round_selection_grid);
+
+    // Hold B on the jokers row to view a description (same binding as the shop)
+    if (game_round_selection_grid.selection.y != GAME_PLAYING_JOKERS_SEL_Y)
+        return;
+
+    JokerObject* focused = list_get_at_idx(
+        get_jokers_list(),
+        game_round_selection_grid.selection.x
+    );
+    if (focused == NULL || focused->vx != 0 || focused->vy != 0 || !key_held(DESELECT_CARDS))
+        return;
+
+    joker_desc_set_active(focused);
+    s_description_card_original_x_pos = focused->x;
+    s_description_card_original_y_pos = focused->y;
+    s_desc_timer = TM_ZERO;
+    s_round_desc_state = ROUND_DESC_SHOWING;
 }
 
 /**
@@ -1054,7 +1256,15 @@ static inline bool game_round_is_over(void)
 
 static inline void game_round_process_input_and_state(void)
 {
-    if (get_hand_state() == HAND_SELECT)
+    if (s_round_desc_state == ROUND_DESC_SHOWING)
+    {
+        game_round_show_joker_desc();
+    }
+    else if (s_round_desc_state == ROUND_DESC_HIDING)
+    {
+        game_round_hide_joker_desc();
+    }
+    else if (get_hand_state() == HAND_SELECT)
     {
         game_round_process_hand_select_input();
     }
@@ -1270,6 +1480,14 @@ static inline void cards_in_hand_update_loop(void)
     {
         if (hand[i] != NULL)
         {
+            // Tuck hand cards toward the bottom only while the desc is opening/open —
+            // leave them partially visible (like the deck). During HIDING they lerp back.
+            if (s_round_desc_state == ROUND_DESC_SHOWING)
+            {
+                hand[i]->ty = int2fx(HAND_CARDS_HIDE_Y);
+                continue;
+            }
+
             FIXED hand_x = int2fx(HAND_START_POS.x);
             FIXED hand_y = int2fx(HAND_START_POS.y);
 
@@ -1296,7 +1514,11 @@ static inline void cards_in_hand_update_loop(void)
                     {
                         hand_y -= int2fx(CARD_FOCUSED_SEL_Y);
                     }
-                    if (i != selected_card_idx && hand[i]->y > hand_y)
+                    // Unfocused cards that sit slightly below their rest y (after losing focus
+                    // raise) snap down. Do NOT snap large gaps — e.g. returning from the
+                    // description hide position — or they teleport instead of animating.
+                    if (i != selected_card_idx && hand[i]->y > hand_y &&
+                        hand[i]->y - hand_y <= int2fx(CARD_FOCUSED_SEL_Y))
                     {
                         hand[i]->y = hand_y;
                         // Set target y to match y. Ensures target is updated even when vy becomes
@@ -1429,6 +1651,7 @@ void toggle_flaming_score(void)
     if (curr_score >= required_score && !s_score_flames_active)
     {
         // start flaming score
+        joker_desc_restore_flame_palette();
         s_score_flames_active = true;
         return;
     }

--- a/source/game/round.c
+++ b/source/game/round.c
@@ -376,12 +376,11 @@ static void game_round_hide_joker_desc(void)
         tte_erase_rect_wrapper(PLAYING_SCREEN_RECT);
         game_round_desc_restore_hand_select_windows();
 
-        // Restore trays/buttons/deck SE, then re-tuck the deck in the same frame so the
-        // next frames can scroll it back up like the shop (no visible snap, no clip).
-        joker_desc_restore_underlay();
+        // Restore trays/buttons from underlay, but leave the deck SE as currently tucked so
+        // we can scroll it back UP (reversible with the taller PLAY_DECK_ANIM_RECT). Re-tucking
+        // after a full restore discards tiles and clips the deck permanently.
+        joker_desc_restore_underlay_except(PLAY_DECK_ANIM_RECT);
         joker_desc_restore_flame_palette();
-        for (int i = 0; i < s_deck_tuck_frames; i++)
-            main_bg_se_move_rect_1_tile_vert(PLAY_DECK_ANIM_RECT, SCREEN_DOWN);
         s_deck_untuck_remaining = s_deck_tuck_frames;
 
         display_deck_size_max();
@@ -411,12 +410,19 @@ static void game_round_hide_joker_desc(void)
         {
             main_bg_se_move_rect_1_tile_vert(PLAY_DECK_ANIM_RECT, SCREEN_UP);
             s_deck_untuck_remaining--;
+            if (s_deck_untuck_remaining == 0)
+            {
+                // Heal flame-atlas SE that the deck tuck temporarily overwrote.
+                joker_desc_restore_underlay_rect(PLAY_DECK_FLAME_SE_RECT);
+                joker_desc_discard_underlay();
+            }
         }
 
         if (description_card->vx == 0 && description_card->vy == 0 && s_deck_untuck_remaining == 0)
         {
             owned_joker_price_printed = false;
             joker_desc_set_active(NULL);
+            joker_desc_discard_underlay();
             s_deck_tuck_frames = 0;
             s_desc_timer = TM_ZERO;
             s_round_desc_state = ROUND_DESC_IDLE;

--- a/source/game/shop.c
+++ b/source/game/shop.c
@@ -12,6 +12,7 @@
 #include "button.h"
 #include "game.h"
 #include "game/blind_select.h"
+#include "game/joker_desc.h"
 #include "game/joker_row.h"
 #include "game_variables.h"
 #include "joker.h"
@@ -31,12 +32,10 @@
 #define TM_END_GAME_SHOP_INTRO    12
 #define TM_CREATE_SHOP_ITEMS_WAIT 1
 #define TM_SHIFT_SHOP_ICON_WAIT   7
-#define TM_SHOW_CARD_DESC_WAIT    12
 #define TM_HIDE_DECK_WAIT         5
 
 // Pixel sized
-#define ITEM_SHOP_Y               71
-#define OWNED_CARDS_HIDE_Y_OFFSET 50
+#define ITEM_SHOP_Y 71
 
 // Shop
 #define REROLL_BASE_COST     5 // Base cost for rerolling the shop items
@@ -69,22 +68,14 @@ static const BG_POINT OWNED_CARDS_PANEL_3X3_SRC_POS = { 29, 21};
 static const Rect     OWNED_JOKERS_PANEL_RECT       = {  9,  1, 21,  5};
 static const Rect     OWNED_CONSUMABLES_PANEL_RECT  = { 23,  1, 28,  5};
 static const Rect     OWNED_CARDS_PANEL_RECT        = {  9,  1, 28,  5};
-static const Rect     OWNED_CARDS_PANEL_ANIM_CLEAR  = {  9,  0, 28,  1};
-static const Rect     CARD_DESC_9_PTCH_TO_RECT      = {  9,  6, 28, 18};
-static const NinePatchRect CARD_DESC_9_PTCH_SRC = {
-                                        .patch_rect = { 27, 25, 31, 31},
-                                        .margins    = {  2,  3,  2,  3}
+static const Rect OWNED_CARDS_PANEL_ANIM_CLEAR = {9, 0, 28, 1};
+static const NinePatchRect SHOP_CARD_DESC_9_PTCH_SRC = {
+    .patch_rect = {27, 25, 31, 31},
+    .margins = {2, 3, 2, 3}
 };
-static const int      CARD_DESC_MAX_TEXT_HEIGHT     = CARD_DESC_9_PTCH_TO_RECT.bottom -
-                                                      CARD_DESC_9_PTCH_TO_RECT.top + 1 -
-                                                      CARD_DESC_9_PTCH_SRC.margins.top -
-                                                      CARD_DESC_9_PTCH_SRC.margins.bottom;
-static const Rect     CARD_DESC_TEXT_RECT           = { 11,  9, 26, 18};
-static const Rect     CARD_NAME_TEXT_RECT           = { 10,  7, 27,  7};
 
 // Positions in pixels
 static const BG_POINT SHOP_JOKER_SPRITES_INIT_POS = {120, 160};
-static const BG_POINT CARD_DESCRIPTION_SPRITE_POS = {135,   9};
 static const Rect     SHOP_PRICES_TEXT_RECT       = { 72,  56, 192, 160 };
 static const Rect     SHOP_REROLL_RECT            = { 88,  96, UNDEFINED, UNDEFINED };
 // clang-format on
@@ -173,7 +164,6 @@ static int s_reroll_cost = REROLL_BASE_COST;
 // Variables relative to the Card we are showing the description of
 
 // TODO: Change this to item once it has description printing API.
-static JokerObject* s_description_card = NULL;
 static FIXED s_description_card_original_x_pos = UNDEFINED;
 static FIXED s_description_card_original_y_pos = UNDEFINED;
 static List* s_description_card_original_list = NULL;
@@ -181,7 +171,7 @@ static int s_show_description_anim_progress = 0;
 
 JokerObject* game_shop_get_description_card(void)
 {
-    return s_description_card;
+    return joker_desc_get_active();
 }
 
 void game_shop_reset(void)
@@ -594,9 +584,9 @@ static void game_shop_process_user_input(void)
     // errors when pressing and releasing B in quick succession.
     if (tmp_card != NULL && tmp_card->vx == 0 && tmp_card->vy == 0 && key_held(DESELECT_CARDS))
     {
-        s_description_card = tmp_card;
-        s_description_card_original_x_pos = s_description_card->x;
-        s_description_card_original_y_pos = s_description_card->y;
+        joker_desc_set_active(tmp_card);
+        s_description_card_original_x_pos = tmp_card->x;
+        s_description_card_original_y_pos = tmp_card->y;
 
         s_timer = TM_ZERO;
         state_machine_change_state(&shop_sm, GAME_SHOP_SHOW_CARD_DESC);
@@ -605,6 +595,8 @@ static void game_shop_process_user_input(void)
 
 static void game_shop_show_card_desc(void)
 {
+    JokerObject* description_card = joker_desc_get_active();
+
     // Anim start
     if (s_timer == 1)
     {
@@ -625,22 +617,22 @@ static void game_shop_show_card_desc(void)
         ListItr itr = list_itr_create(get_jokers_list());
         while ((joker_object = list_itr_next(&itr)))
         {
-            if (joker_object != s_description_card)
-                joker_object->ty -= int2fx(OWNED_CARDS_HIDE_Y_OFFSET);
+            if (joker_object != description_card)
+                joker_object->ty -= int2fx(JOKER_DESC_OWNED_HIDE_Y_OFFSET);
         }
 
         // Shop Jokers
         itr = list_itr_create(&s_shop_items_list);
         while ((joker_object = list_itr_next(&itr)))
         {
-            if (joker_object != s_description_card)
+            if (joker_object != description_card)
                 joker_object->ty = int2fx(SHOP_JOKER_SPRITES_INIT_POS.y + TILE_SIZE);
         }
 
         // Set description_card new target position
 
-        s_description_card->tx = int2fx(CARD_DESCRIPTION_SPRITE_POS.x);
-        s_description_card->ty = int2fx(CARD_DESCRIPTION_SPRITE_POS.y);
+        description_card->tx = int2fx(JOKER_DESC_SPRITE_POS.x);
+        description_card->ty = int2fx(JOKER_DESC_SPRITE_POS.y);
     }
 
     if (s_timer <= TM_SHOW_CARD_DESC_WAIT)
@@ -659,41 +651,11 @@ static void game_shop_show_card_desc(void)
     // Anim end
     else if (s_timer == TM_SHOW_CARD_DESC_WAIT + 1)
     {
-        // Compute needed space for the description
-        const JokerInfo* info = get_joker_registry_entry(s_description_card->joker->id);
-        int desc_bottom_offset =
-            CARD_DESC_MAX_TEXT_HEIGHT -
-            info->joker_print_desc(s_description_card->joker, CARD_DESC_TEXT_RECT);
-
-        // Print Rarity and change color or the panel
-        // Do it before drawing the panel so the color is already set
-        const char* rarity_str = joker_get_rarity_string(info->rarity);
-        tte_printf(
-            TTE_WHITE_TAG "#{P:%d,%d}%*s%s",
-            CARD_DESC_TEXT_RECT.left * TILE_SIZE,
-            (CARD_DESC_TEXT_RECT.bottom - desc_bottom_offset - 1) * TILE_SIZE,
-            (rect_width(&CARD_DESC_TEXT_RECT) - strlen(rarity_str)) / 2,
-            "",
-            rarity_str
-        );
-        pal_bg_mem[SHOP_DESC_RARITY_MAIN_COLOR_PAL_IDX] =
-            joker_get_rarity_color(info->rarity, true);
-        pal_bg_mem[SHOP_DESC_RARITY_SHADOW_COLOR_PAL_IDX] =
-            joker_get_rarity_color(info->rarity, false);
-
-        // Draw description panel
-        Rect actual_dest_rect = CARD_DESC_9_PTCH_TO_RECT;
-        actual_dest_rect.bottom -= desc_bottom_offset;
-        main_bg_se_copy_expand_9_patch(actual_dest_rect, &CARD_DESC_9_PTCH_SRC);
-
-        // Print joker name
-        tte_printf(
-            TTE_WHITE_TAG "#{P:%d,%d}%*s%s",
-            CARD_NAME_TEXT_RECT.left * TILE_SIZE,
-            CARD_NAME_TEXT_RECT.top * TILE_SIZE,
-            (rect_width(&CARD_NAME_TEXT_RECT) - strlen(info->name)) / 2,
-            "",
-            info->name
+        joker_desc_draw_panel(
+            description_card->joker,
+            &SHOP_CARD_DESC_9_PTCH_SRC,
+            SHOP_DESC_RARITY_MAIN_COLOR_PAL_IDX,
+            SHOP_DESC_RARITY_SHADOW_COLOR_PAL_IDX
         );
     }
 
@@ -709,6 +671,7 @@ static void game_shop_hide_card_desc(void)
 {
     // just so we don't print the price of an owned Joker too many times
     static bool owned_joker_price_printed = false;
+    JokerObject* description_card = joker_desc_get_active();
 
     // Anim start
     if (s_timer == 1)
@@ -716,7 +679,7 @@ static void game_shop_hide_card_desc(void)
         // Erase shop text and Joker Description frame if we had time to draw them
         if (s_show_description_anim_progress >= TM_SHOW_CARD_DESC_WAIT)
         {
-            main_bg_se_clear_rect(CARD_DESC_9_PTCH_TO_RECT);
+            joker_desc_clear_panel();
         }
         // Or clear the owned cards' panel that haven't finished moving up
         else
@@ -743,7 +706,7 @@ static void game_shop_hide_card_desc(void)
         ListItr itr = list_itr_create(get_jokers_list());
         while ((joker_object = list_itr_next(&itr)))
         {
-            if (joker_object != s_description_card)
+            if (joker_object != description_card)
                 joker_object->ty = int2fx(HELD_JOKERS_POS.y);
         }
 
@@ -751,12 +714,12 @@ static void game_shop_hide_card_desc(void)
         itr = list_itr_create(&s_shop_items_list);
         while ((joker_object = list_itr_next(&itr)))
         {
-            if (joker_object != s_description_card)
+            if (joker_object != description_card)
                 joker_object->ty = int2fx(ITEM_SHOP_Y);
         }
 
-        s_description_card->tx = s_description_card_original_x_pos;
-        s_description_card->ty = s_description_card_original_y_pos;
+        description_card->tx = s_description_card_original_x_pos;
+        description_card->ty = s_description_card_original_y_pos;
     }
 
     if (s_timer <= s_show_description_anim_progress)
@@ -776,7 +739,7 @@ static void game_shop_hide_card_desc(void)
     {
         // Need to account for the description_card being selected if it came from the shop.
         if (s_description_card_original_list == &s_shop_items_list)
-            s_description_card->ty += int2fx(TILE_SIZE);
+            description_card->ty += int2fx(TILE_SIZE);
 
         // Print price under shop Jokers
         Item* item = NULL;
@@ -787,7 +750,7 @@ static void game_shop_hide_card_desc(void)
         }
 
         if (s_description_card_original_list == &s_shop_items_list)
-            s_description_card->ty -= int2fx(TILE_SIZE);
+            description_card->ty -= int2fx(TILE_SIZE);
 
         // Print Reroll prince
         tte_printf(
@@ -803,10 +766,10 @@ static void game_shop_hide_card_desc(void)
     }
 
     // Cleanup and change state
-    else if (s_description_card->vx == 0 && s_description_card->vy == 0)
+    else if (description_card->vx == 0 && description_card->vy == 0)
     {
         owned_joker_price_printed = false;
-        s_description_card = NULL;
+        joker_desc_set_active(NULL);
         s_timer = TM_ZERO;
         state_machine_change_state(&shop_sm, GAME_SHOP_ACTIVE);
     }
@@ -818,8 +781,8 @@ static void game_shop_hide_card_desc(void)
     {
         owned_joker_price_printed = true;
         sprite_object_print_price_under(
-            (SpriteObject*)s_description_card,
-            joker_get_sell_value(s_description_card->joker)
+            (SpriteObject*)description_card,
+            joker_get_sell_value(description_card->joker)
         );
     }
 }


### PR DESCRIPTION
## Summary
- Hold B on a focused joker during a round shows the same description overlay as the shop (shared `joker_desc` module).
- Round UI tucks the hand/joker trays and partially hides the deck while the panel is open; underlay restore brings play SE back cleanly on close.
- Avoids score-flame corruption: deck scroll no longer covers the flame atlas, and rarity stripe colors use free palette slots (32/33) instead of flame indices 27/28.

## Test plan
- [ ] Shop: Hold B on owned/shop jokers still shows description and restores UI on release
- [ ] Round: Hold B on joker row shows description panel; release restores trays, buttons, and deck
- [ ] Deck peeks partially while desc is open; full deck returns after close
- [ ] Trigger score flames (beat blind requirement); flames look correct after opening/closing a joker desc
- [ ] Play Hand / Discard buttons remain visible during hand select (outside WIN0 blend)