### PR TITLE
[Refactor] Replaced rogue call to obj_hide with sprite_object_hide

### DIFF
--- a/source/game/game_over.c
+++ b/source/game/game_over.c
@@ -143,7 +143,7 @@ static void game_over_common_init(enum EndCondition init_condition)
     ListItr itr = list_itr_create(get_jokers_list());
     while ((joker_object = list_itr_next(&itr)))
     {
-        obj_hide(joker_object->sprite->obj);
+        sprite_object_hide((SpriteObject*)(joker_object));
     }
 
     // Destroy any preexisting cards in the deck, which will be present if we restart a run


### PR DESCRIPTION
I noticed this call to `obj_hide()` that I seem to have missed in #563, so I properly replaced it with the correct function call.